### PR TITLE
fix: support generic + typeAliasIndex

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -2,6 +2,7 @@
 
 const debug = require('debug')('hessian#compile');
 const utils = require('./utils');
+const has = require('utility').has;
 const codegen = require('@protobufjs/codegen');
 
 const cache = new Map();
@@ -126,7 +127,10 @@ function compile(uniqueId, info, classMap, version) {
       gen('encoder.writeType(\'%s\');', type);
       for (const key of keys) {
         gen('encoder.writeString(\'%s\');', key);
-        const attr = classInfo[key];
+        const attr = Object.assign({}, classInfo[key]);
+        if (has(attr, 'typeAliasIndex') && Array.isArray(info.generic)) {
+          attr.type = info.generic[attr.typeAliasIndex].type;
+        }
         const uniqueId = utils.normalizeUniqId(attr, version);
         gen('compile(\'%s\', %j, classMap, version)(obj[\'%s\'], encoder, appClassMap);', uniqueId, attr, key);
       }
@@ -141,7 +145,10 @@ function compile(uniqueId, info, classMap, version) {
       gen('encoder._writeObjectBegin(\'%s\'); }', type);
 
       for (const key of keys) {
-        const attr = classInfo[key];
+        const attr = Object.assign({}, classInfo[key]);
+        if (has(attr, 'typeAliasIndex') && Array.isArray(info.generic)) {
+          attr.type = info.generic[attr.typeAliasIndex].type;
+        }
         const uniqueId = utils.normalizeUniqId(attr, version);
         gen('compile(\'%s\', %j, classMap, version)(obj[\'%s\'], encoder, appClassMap);', uniqueId, attr, key);
       }

--- a/package.json
+++ b/package.json
@@ -35,14 +35,15 @@
   "dependencies": {
     "@protobufjs/codegen": "^2.0.4",
     "debug": "^3.1.0",
-    "hessian.js-1": "^1.8.2"
+    "hessian.js-1": "^1.8.2",
+    "utility": "^1.14.0"
   },
   "devDependencies": {
     "autod": "^3.0.1",
     "beautify-benchmark": "^0.2.4",
     "benchmark": "^2.1.4",
     "contributors": "^0.5.1",
-    "egg-bin": "^4.7.0",
+    "egg-bin": "^4.7.1",
     "egg-ci": "^1.8.0",
     "eslint": "^5.0.1",
     "eslint-config-egg": "^7.0.0",

--- a/test/fixtures/class_map.js
+++ b/test/fixtures/class_map.js
@@ -240,4 +240,11 @@ module.exports = {
       isStatic: true,
     },
   },
+
+  'com.alipay.test.Request': {
+    'data': {
+      'type': 'T',
+      'typeAliasIndex': 0,
+    },
+  },
 };

--- a/test/hessian.test.js
+++ b/test/hessian.test.js
@@ -997,6 +997,27 @@ describe('test/hessian.test.js', () => {
         const buf4 = encode(converted, version);
         assert.deepEqual(buf1, buf4);
       });
+
+      it('should support generic with typeAliasIndex', () => {
+        const obj = {
+          $class: 'com.alipay.test.Request',
+          $: {
+            data: '123',
+          },
+          generic: [{ type: 'java.lang.String' }],
+        };
+        const buf1 = hessian.encode({
+          $class: 'com.alipay.test.Request',
+          $: {
+            data: { $class: 'java.lang.String', $: '123' },
+          },
+        }, version);
+        const buf2 = encode(obj, version, classMap);
+        assert.deepEqual(buf1, buf2);
+
+        const buf3 = encode(obj, version, classMap);
+        assert.deepEqual(buf1, buf3);
+      });
     });
   });
 });


### PR DESCRIPTION
classMap 如下:

```js
{
  'com.alipay.test.Request': {
    'data': {
      'type': 'T',
      'typeAliasIndex': 0,
    },
  },
};
```

`data` 是泛型，需要根据 `generic[typeAliasIndex]` 来确定实际类型

```js
encode({
  $class: 'com.alipay.test.Request',
  $: {
    data: '123',
  },
  generic: [{ type: 'java.lang.String' }],
}, '2.0', classMap);
```