### PR TITLE
fix: encode enum defaultValue issue & list generic issue

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -160,7 +160,6 @@ function compile(uniqueId, info, classMap, version) {
     }
   } else if (info.isEnum) {
     gen('if (obj == null) { return encoder.writeNull(); }');
-    gen('if (encoder._checkRef(obj)) { return; }');
 
     if (version === '1.0') {
       gen('encoder.byteBuffer.put(0x4d);');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,6 +3,15 @@
 const defaultValueMap = new Map();
 let defaultValueId = 0;
 
+function normalizeGeneric(type) {
+  if (!type.generic) return '';
+  let str = '';
+  for (const item of type.generic) {
+    str += ('#' + item.type + normalizeGeneric(item));
+  }
+  return str;
+}
+
 function normalizeUniqId(info, version) {
   let type = info.type || info.$class || info.$abstractClass;
   if (info.isArray) {
@@ -10,11 +19,7 @@ function normalizeUniqId(info, version) {
     while (arrayDepth--) type = '[' + type;
   }
   let fnKey = type;
-  if (info.generic) {
-    for (const item of info.generic) {
-      fnKey += ('#' + item.type);
-    }
-  }
+  fnKey += normalizeGeneric(info);
   if (info.defaultValue) {
     if (!defaultValueMap.has(info.defaultValue)) {
       defaultValueMap.set(info.defaultValue, defaultValueId++);

--- a/package.json
+++ b/package.json
@@ -34,19 +34,19 @@
   "homepage": "https://github.com/alipay/sofa-hessian-node#readme",
   "dependencies": {
     "@protobufjs/codegen": "^2.0.4",
-    "debug": "^3.1.0",
-    "hessian.js-1": "^1.8.3",
-    "utility": "^1.14.0"
+    "debug": "^4.1.0",
+    "hessian.js-1": "^1.8.4",
+    "utility": "^1.15.0"
   },
   "devDependencies": {
     "autod": "^3.0.1",
     "beautify-benchmark": "^0.2.4",
     "benchmark": "^2.1.4",
     "contributors": "^0.5.1",
-    "egg-bin": "^4.8.1",
-    "egg-ci": "^1.8.0",
-    "eslint": "^5.2.0",
-    "eslint-config-egg": "^7.0.0",
+    "egg-bin": "^4.9.0",
+    "egg-ci": "^1.10.0",
+    "eslint": "^5.7.0",
+    "eslint-config-egg": "^7.1.0",
     "js-to-java": "^2.6.0",
     "long": "^4.0.0"
   },

--- a/test/fixtures/class_map.js
+++ b/test/fixtures/class_map.js
@@ -260,4 +260,20 @@ module.exports = {
       'typeAliasIndex': 0,
     },
   },
+
+  'com.sofa.TestObject': {
+    'oneEnum': {
+      'type': 'com.sofa.OneEnum',
+      'defaultValue': 'DEFAULT',
+      'isEnum': true,
+    },
+    /**
+     * 对业务影响分级
+     */
+    'twoEnum': {
+      'type': 'com.sofa.TwoEnum',
+      'defaultValue': 'DEFAULT',
+      'isEnum': true,
+    },
+  },
 };

--- a/test/hessian.test.js
+++ b/test/hessian.test.js
@@ -1049,6 +1049,21 @@ describe('test/hessian.test.js', () => {
         const buf3 = encode(obj, version, classMap);
         assert.deepEqual(buf1, buf3);
       });
+
+      it('should handle same enum defaultValue', () => {
+        const buf1 = hessian.encode({
+          $class: 'com.sofa.TestObject',
+          $: {
+            oneEnum: { $class: 'com.sofa.OneEnum', $: { name: 'DEFAULT' } },
+            twoEnum: { $class: 'com.sofa.TwoEnum', $: { name: 'DEFAULT' } },
+          },
+        }, version);
+        const buf2 = encode({
+          $class: 'com.sofa.TestObject',
+          $: {},
+        }, version, classMap);
+        assert.deepEqual(buf1, buf2);
+      });
     });
   });
 });

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const assert = require('assert');
+const utils = require('../lib/utils');
+
+describe('test/util.test.js', () => {
+  it('should handle generic', () => {
+    const info = {
+      $class: 'java.util.List',
+      $: [],
+      generic: [{
+        type: 'java.util.List',
+        generic: [{ type: 'com.sofa.testObject' }],
+      }],
+    };
+    let id = utils.normalizeUniqId(info, '2.0');
+    assert(id === 'java.util.List#java.util.List#com.sofa.testObject#2.0');
+    id = utils.normalizeUniqId(info, '1.0');
+    assert(id === 'java.util.List#java.util.List#com.sofa.testObject#1.0');
+  });
+});


### PR DESCRIPTION
修复了两个问题

1. 对于两个不同的枚举类型，但是相同的 defaultValue 时，可能会串
```js
{
  'com.sofa.TestObject': {
    'oneEnum': {
      'type': 'com.sofa.OneEnum',
      'defaultValue': 'DEFAULT',
      'isEnum': true,
    },
    'twoEnum': {
      'type': 'com.sofa.TwoEnum',
      'defaultValue': 'DEFAULT',
      'isEnum': true,
    },
  },
```
如果 oneEnum 和 twoEnum 的值一样，第二个会直接饮用第一个，但实际上他们的类型是不同的

2. 参数如果是泛型的 list，计算缓存 id 逻辑有点问题，也会导致串掉

```js
{
      $class: 'java.util.List',
      $: [],
      generic: [{
        type: 'java.util.List',
        generic: [{ type: 'com.sofa.testObject' }],
      }],
    }
```
这种参数计算出来应该是 `java.util.List#java.util.List#com.sofa.testObject#2.0` 以前计算出来是 `java.util.List#java.util.Lis#2.0`