### PR TITLE
feat: add debug mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ run
 !.travis.yml
 !.autod.conf.js
 *.bin
+
+test/fixtures/src_1.0
+test/fixtures/src_2.0

--- a/index.js
+++ b/index.js
@@ -5,11 +5,15 @@ const compile = require('./lib/compile');
 const encoderV1 = require('hessian.js-1').encoderV1;
 const encoderV2 = require('hessian.js-1').encoderV2;
 
-exports.encode = (obj, version, classMap, appClassMap) => {
+exports.encode = (obj, version, classMap, appClassMap, options) => {
+  options = Object.assign({}, options, {
+    debug: !!process.env.HESSIAN_COMPILE_DEBUG,
+    debugDir: process.env.HESSIAN_COMPILE_DEBUG_DIR,
+  });
   const encoder = version === '2.0' ? encoderV2 : encoderV1;
   encoder.reset();
   if (classMap) {
-    compile(obj, version, classMap)(obj.$, encoder, appClassMap);
+    compile(obj, version, classMap, options)(obj.$, encoder, appClassMap);
   } else {
     encoder.write(obj);
   }

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -1,9 +1,11 @@
 'use strict';
 
-const debug = require('debug')('hessian#compile');
 const utils = require('./utils');
 const has = require('utility').has;
 const codegen = require('@protobufjs/codegen');
+const path = require('path');
+const fs = require('fs');
+const assert = require('assert');
 
 const cache = new Map();
 const typeMap = {
@@ -55,15 +57,18 @@ const bufferType = {
  *   - {String} $class - 类名
  * @param {String} version - hessian 版本：1.0, 2.0
  * @param {Object} classMap - 类型映射
+ * @param {Object} options - compile 参数
+ * @param {Boolean} options.debug - 预编译文件是否落盘
+ * @param {String} options.debugDir - 落盘位置
  * @return {Function} serializeFn
  */
-module.exports = (info, version, classMap) => {
+module.exports = (info, version, classMap, options) => {
   info.type = info.type || info.$class;
   const uniqueId = utils.normalizeUniqId(info, version);
-  return compile(uniqueId, info, classMap, version);
+  return compile(uniqueId, info, classMap, version, options);
 };
 
-function compile(uniqueId, info, classMap, version) {
+function compile(uniqueId, info, classMap, version, options) {
   let encodeFn = cache.get(uniqueId);
   if (encodeFn) return encodeFn;
 
@@ -105,19 +110,19 @@ function compile(uniqueId, info, classMap, version) {
       };
       const uniqueId = utils.normalizeUniqId(item, version);
       gen('for (const item of obj) {');
-      gen('  compile(\'%s\', %j, classMap, version)(item, encoder, appClassMap);', uniqueId, item);
+      gen('  compile(\'%s\', %j, classMap, version, %j)(item, encoder, appClassMap);', uniqueId, item, options);
       gen('}');
       gen('if (hasEnd) { encoder.byteBuffer.putChar(\'z\'); }');
     }
   } else if (typeMap[type]) {
-    typeMap[type](gen, info, version);
+    typeMap[type](gen, info, version, options);
   } else if (info.isMap) {
-    typeMap['java.util.Map'](gen, info, version);
+    typeMap['java.util.Map'](gen, info, version, options);
   } else if (classInfo && !info.abstractClass && !info.$abstractClass) {
     gen('if (obj == null) { return encoder.writeNull(); }');
     gen('if (obj && obj.$class) {');
     gen('  const fnKey = utils.normalizeUniqId(obj, version);');
-    gen('  compile(fnKey, obj, classMap, version)(obj.$, encoder, appClassMap);');
+    gen('  compile(fnKey, obj, classMap, version, %j)(obj.$, encoder, appClassMap);', options);
     gen('  return;');
     gen('}');
     gen('if (encoder._checkRef(obj)) { return; }');
@@ -137,7 +142,7 @@ function compile(uniqueId, info, classMap, version) {
           attr.type = info.generic[attr.typeAliasIndex].type;
         }
         const uniqueId = utils.normalizeUniqId(attr, version);
-        gen('compile(\'%s\', %j, classMap, version)(obj[\'%s\'], encoder, appClassMap);', uniqueId, attr, key);
+        gen('compile(\'%s\', %j, classMap, version, %j)(obj[\'%s\'], encoder, appClassMap);', uniqueId, attr, options, key);
       }
       gen('encoder.byteBuffer.put(0x7a);');
     } else {
@@ -155,7 +160,7 @@ function compile(uniqueId, info, classMap, version) {
           attr.type = info.generic[attr.typeAliasIndex].type;
         }
         const uniqueId = utils.normalizeUniqId(attr, version);
-        gen('compile(\'%s\', %j, classMap, version)(obj[\'%s\'], encoder, appClassMap);', uniqueId, attr, key);
+        gen('compile(\'%s\', %j, classMap, version, %j)(obj[\'%s\'], encoder, appClassMap);', uniqueId, attr, options, key);
       }
     }
   } else if (info.isEnum) {
@@ -180,12 +185,25 @@ function compile(uniqueId, info, classMap, version) {
     gen('if (obj == null) { return encoder.writeNull(); }');
     gen('if (obj && obj.$class) {');
     gen('  const fnKey = utils.normalizeUniqId(obj, version);');
-    gen('  compile(fnKey, obj, classMap, version)(obj.$, encoder, appClassMap);');
+    gen('  compile(fnKey, obj, classMap, version, %j)(obj.$, encoder, appClassMap);', options);
     gen('}');
     gen('else { encoder.write({ $class: \'%s\', $: obj }); }', type);
   }
-  encodeFn = gen({ compile, classMap, version, utils });
-  debug('gen encodeFn for [%s] => %s\n', uniqueId, '\n' + encodeFn.toString());
+  if (!options.debug) {
+    encodeFn = gen({ compile, classMap, version, utils });
+  } else {
+    assert(options.debugDir, 'debugDir is empty, please set debugDir in options or HESSIAN_COMPILE_DEBUG_DIR');
+    const func = `
+module.exports = function (compile, classMap, version, utils) {
+  return ${gen.toString()};
+};
+`;
+    const jsFile = path.join(options.debugDir, `${uniqueId}.js`);
+    fs.writeFileSync(jsFile, func);
+    encodeFn = require(jsFile)(compile, classMap, version, utils);
+  }
   cache.set(uniqueId, encodeFn);
   return encodeFn;
 }
+
+module.exports.cache = cache;

--- a/lib/primitive_type/java.lang.exception.js
+++ b/lib/primitive_type/java.lang.exception.js
@@ -2,7 +2,7 @@
 
 const utils = require('../utils');
 
-module.exports = (gen, classInfo, version) => {
+module.exports = (gen, classInfo, version, options) => {
   gen('if (obj == null) { return encoder.writeNull(); }');
 
   gen('if (encoder._checkRef(obj)) { return; }');
@@ -52,7 +52,7 @@ module.exports = (gen, classInfo, version) => {
       gen('encoder.writeString(\'%s\');', key);
       const attr = classInfo[key];
       const uniqueId = utils.normalizeUniqId(attr, version);
-      gen('compile(\'%s\', %j, classMap, version)(obj[\'%s\'], encoder);', uniqueId, attr, key);
+      gen('compile(\'%s\', %j, classMap, version, %j)(obj[\'%s\'], encoder);', uniqueId, attr, options, key);
     }
     gen('encoder.byteBuffer.put(0x7a);');
   } else {
@@ -67,7 +67,7 @@ module.exports = (gen, classInfo, version) => {
     for (const key of keys) {
       const attr = classInfo[key];
       const uniqueId = utils.normalizeUniqId(attr, version);
-      gen('compile(\'%s\', %j, classMap, version)(obj[\'%s\'], encoder);', uniqueId, attr, key);
+      gen('compile(\'%s\', %j, classMap, version, %j)(obj[\'%s\'], encoder);', uniqueId, attr, options, key);
     }
   }
 };

--- a/lib/primitive_type/java.lang.object.js
+++ b/lib/primitive_type/java.lang.object.js
@@ -1,10 +1,10 @@
 'use strict';
 
-module.exports = gen => {
+module.exports = (gen, classInfo, version, options) => {
   gen('if (obj == null) { return encoder.writeNull(); }');
   gen('if (obj && obj.$class) {');
   gen('  const fnKey = utils.normalizeUniqId(obj, version);');
-  gen('  compile(fnKey, obj, appClassMap, version)(obj.$, encoder);');
+  gen('  compile(fnKey, obj, appClassMap, version, %j)(obj.$, encoder);', options);
   gen('} else {');
   gen('  encoder.write(obj);');
   gen('}');

--- a/lib/primitive_type/java.lang.stacktraceelement.js
+++ b/lib/primitive_type/java.lang.stacktraceelement.js
@@ -2,7 +2,7 @@
 
 const utils = require('../utils');
 
-module.exports = (gen, classInfo, version) => {
+module.exports = (gen, classInfo, version, options) => {
   gen('if (obj == null) { return encoder.writeNull(); }');
   gen('if (encoder._checkRef(obj)) { return; }');
 
@@ -29,7 +29,7 @@ module.exports = (gen, classInfo, version) => {
       gen('encoder.writeString(\'%s\');', key);
       const attr = classInfo[key];
       const uniqueId = utils.normalizeUniqId(attr, version);
-      gen('compile(\'%s\', %j, classMap, version)(obj[\'%s\'], encoder);', uniqueId, attr, key);
+      gen('compile(\'%s\', %j, classMap, version, %j)(obj[\'%s\'], encoder);', uniqueId, attr, options, key);
     }
     gen('encoder.byteBuffer.put(0x7a);');
   } else {
@@ -44,7 +44,7 @@ module.exports = (gen, classInfo, version) => {
     for (const key of keys) {
       const attr = classInfo[key];
       const uniqueId = utils.normalizeUniqId(attr, version);
-      gen('compile(\'%s\', %j, classMap, version)(obj[\'%s\'], encoder);', uniqueId, attr, key);
+      gen('compile(\'%s\', %j, classMap, version, %j)(obj[\'%s\'], encoder);', uniqueId, attr, options, key);
     }
   }
 };

--- a/lib/primitive_type/java.util.arraylist.js
+++ b/lib/primitive_type/java.util.arraylist.js
@@ -2,7 +2,7 @@
 
 const utils = require('../utils');
 
-module.exports = (gen, classInfo, version) => {
+module.exports = (gen, classInfo, version, options) => {
   gen('if (obj == null) { return encoder.writeNull(); }');
   gen('if (encoder._checkRef(obj)) { return; }');
 
@@ -19,7 +19,7 @@ module.exports = (gen, classInfo, version) => {
     gen('  } else {');
     gen('    desc = %j;', genericDefine);
     gen('  }');
-    gen('  compile(\'%s\', desc, classMap, version)(item, encoder, appClassMap);', uniqueId);
+    gen('  compile(\'%s\', desc, classMap, version, %j)(item, encoder, appClassMap);', uniqueId, options);
     gen('}');
   } else {
     gen('for (const item of obj) { encoder.write(item); }');

--- a/lib/primitive_type/java.util.list.js
+++ b/lib/primitive_type/java.util.list.js
@@ -2,7 +2,7 @@
 
 const utils = require('../utils');
 
-module.exports = (gen, classInfo, version) => {
+module.exports = (gen, classInfo, version, options) => {
   gen('if (obj == null) { return encoder.writeNull(); }');
   gen('if (obj.$class) { obj = obj.$; }');
   gen('if (obj == null) { return encoder.writeNull(); }');
@@ -36,7 +36,7 @@ module.exports = (gen, classInfo, version) => {
     gen('  } else {');
     gen('   desc = %j;', genericDefine);
     gen('  }');
-    gen('  compile(uniqueId, desc, classMap, version)(val, encoder, appClassMap);');
+    gen('  compile(uniqueId, desc, classMap, version, %j)(val, encoder, appClassMap);', options);
     gen('}');
   } else {
     gen('for (const item of obj) { encoder.write(item); }');

--- a/lib/primitive_type/java.util.map.js
+++ b/lib/primitive_type/java.util.map.js
@@ -2,7 +2,7 @@
 
 const utils = require('../utils');
 
-module.exports = (gen, classInfo, version) => {
+module.exports = (gen, classInfo, version, options) => {
   gen('if (obj == null) { return encoder.writeNull(); }');
   gen('if (encoder._checkRef(obj)) { return; }');
 
@@ -23,18 +23,18 @@ module.exports = (gen, classInfo, version) => {
     const genericValueDefine = utils.normalizeType(generic[1]);
     const keyId = utils.normalizeUniqId(genericKeyDefine, version);
     const valueId = utils.normalizeUniqId(genericValueDefine, version);
-    gen('    const encodeKey = compile(\'%s\', %j, classMap, version); encodeKey(key, encoder, appClassMap);', keyId, genericKeyDefine);
-    gen('    const encodeValue = compile(\'%s\', %j, classMap, version); encodeValue(value, encoder, appClassMap);', valueId, genericValueDefine);
+    gen('    const encodeKey = compile(\'%s\', %j, classMap, version, %j); encodeKey(key, encoder, appClassMap);', keyId, genericKeyDefine, options);
+    gen('    const encodeValue = compile(\'%s\', %j, classMap, version, %j); encodeValue(value, encoder, appClassMap);', valueId, genericValueDefine, options);
     gen('  }\n  } else {');
     gen('  for (const key in obj) {');
     gen('    const value = obj[key];');
     const convertor = utils.converts[genericKeyDefine.type];
     if (convertor) {
-      gen('    const encodeKey = compile(\'%s\', %j, classMap, version); encodeKey(%s(key), encoder, appClassMap);', keyId, genericKeyDefine, convertor);
+      gen('    const encodeKey = compile(\'%s\', %j, classMap, version, %j); encodeKey(%s(key), encoder, appClassMap);', keyId, genericKeyDefine, options, convertor);
     } else {
-      gen('    const encodeKey = compile(\'%s\', %j, classMap, version); encodeKey(key, encoder, appClassMap);', keyId, genericKeyDefine);
+      gen('    const encodeKey = compile(\'%s\', %j, classMap, version, %j); encodeKey(key, encoder, appClassMap);', keyId, genericKeyDefine, options);
     }
-    gen('    const encodeValue = compile(\'%s\', %j, classMap, version); encodeValue(value, encoder, appClassMap);', valueId, genericValueDefine);
+    gen('    const encodeValue = compile(\'%s\', %j, classMap, version, %j); encodeValue(value, encoder, appClassMap);', valueId, genericValueDefine, options);
     gen('  }\n  }');
   } else {
     gen('if (obj instanceof Map) {');
@@ -44,7 +44,7 @@ module.exports = (gen, classInfo, version) => {
     gen('    encoder.writeString(key);');
     gen('    if (value && value.$class) {');
     gen('      const fnKey = utils.normalizeUniqId(value, version);');
-    gen('      compile(fnKey, value, appClassMap, version)(value.$, encoder);');
+    gen('      compile(fnKey, value, appClassMap, version, %j)(value.$, encoder);', options);
     gen('    } else {');
     gen('      encoder.write(value);');
     gen('    }');
@@ -54,7 +54,7 @@ module.exports = (gen, classInfo, version) => {
     gen('    encoder.writeString(key);');
     gen('    if (value && value.$class) {');
     gen('      const fnKey = utils.normalizeUniqId(value, version);');
-    gen('      compile(fnKey, value, appClassMap, version)(value.$, encoder);');
+    gen('      compile(fnKey, value, appClassMap, version, %j)(value.$, encoder);', options);
     gen('    } else {');
     gen('      encoder.write(value);');
     gen('    }');

--- a/package.json
+++ b/package.json
@@ -48,7 +48,10 @@
     "eslint": "^5.11.1",
     "eslint-config-egg": "^7.1.0",
     "js-to-java": "^2.6.0",
-    "long": "^4.0.0"
+    "long": "^4.0.0",
+    "mkdirp": "^0.5.1",
+    "mm": "^2.4.1",
+    "rimraf": "^2.6.3"
   },
   "engines": {
     "node": ">= 8.0.0"


### PR DESCRIPTION
When debug mode is true, will write compiled function to debugDir.

Usage:
```js
encode(obj, '2.0', classMap, appClassMap, {
  debug: true,
  debugDir: '/tmp',
});
```

Or use env: `HESSIAN_COMPILE_DEBUG`, `HESSIAN_COMPILE_DEBUG_DIR`