### PR TITLE
feat: support generic param pass case with typeVar=true

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -76,6 +76,12 @@ module.exports = (info, version, classMap, options = {}) => {
 
 function compileProp(gen, info, key, classInfo, version, options) {
   const attr = Object.create(null, Object.getOwnPropertyDescriptors(classInfo[key]));
+
+  // generic param pass handle
+  if (Array.isArray(attr.generic)) {
+    parseGenericTypeVar(attr.generic, info, attr);
+  }
+
   if (has(attr, 'typeAliasIndex') && Array.isArray(info.generic)) {
     attr.type = info.generic[attr.typeAliasIndex].type;
     if (info.generic[attr.typeAliasIndex].generic) {
@@ -90,6 +96,23 @@ function compileProp(gen, info, key, classInfo, version, options) {
     Object.defineProperty(attr, 'defaultValue', Object.assign({}, desc, { enumerable: false }));
     const dv = desc.get ? `({ ${utils.getterStringify(desc.get)} }).defaultValue` : JSON.stringify(desc.value);
     gen('compile(\'%s\', %j, classMap, version, %j)(utils.has(obj, \'%s\') ? obj[\'%s\'] : %s, encoder, appClassMap);', uniqueId, attr, options, key, key, dv);
+  }
+}
+
+function parseGenericTypeVar(generic, info) {
+  for (const genericItem of generic) {
+    if (genericItem.typeVar === true && has(genericItem, 'typeAliasIndex') && Array.isArray(info.generic)) {
+      genericItem.type = info.generic[genericItem.typeAliasIndex].type;
+
+      if (info.generic[genericItem.typeAliasIndex].generic) {
+        genericItem.generic = info.generic[genericItem.typeAliasIndex].generic;
+      }
+    }
+
+    // recursive handle
+    if (Array.isArray(genericItem.generic)) {
+      parseGenericTypeVar(genericItem.generic, info);
+    }
   }
 }
 

--- a/test/fixtures/class_map.js
+++ b/test/fixtures/class_map.js
@@ -303,4 +303,42 @@ module.exports = {
       'type': 'java.lang.String'
     }
   },
+
+  // pass generic
+  'com.eggjs.dubbo.ComplexGenericParams': {
+    'useGenericIndex0': {
+      'type': 'T',
+      'typeAliasIndex': 0
+    },
+    'useGenericIndex1': {
+      'type': 'java.util.List',
+      'generic': [{
+        'typeVar': true,
+        'type':'S',
+        'typeAliasIndex': 1,
+      }]
+    },
+    'passGeneric': {
+      'type': 'com.eggjs.dubbo.PassGeneric',
+      'generic': [{
+        'typeVar': true,
+        'type':'T',
+        'typeAliasIndex': 0,
+      }, {
+        'typeVar': true,
+        'type':'S',
+        'typeAliasIndex': 1,
+      }],
+    },
+  },
+  'com.eggjs.dubbo.PassGeneric': {
+    'propertyIndex0': {
+      'type': 'E',
+      'typeAliasIndex': 0
+    },
+    'propertyIndex1': {
+      'type': 'R',
+      'typeAliasIndex': 1
+    },
+  },
 };

--- a/test/hessian.test.js
+++ b/test/hessian.test.js
@@ -1244,6 +1244,235 @@ describe('test/hessian.test.js', () => {
         assert.deepEqual(buf1, buf3);
       });
 
+      it('should support nested and pass generic', () => {
+        const obj = {
+          $class: 'com.eggjs.dubbo.ComplexGenericParams',
+          $: {
+            useGenericIndex0: {
+              useGenericIndex0: 'String',
+              useGenericIndex1: [ 'String' ],
+              passGeneric: {
+                propertyIndex0: 'String',
+                propertyIndex1: 'String',
+              },
+            },
+            useGenericIndex1: [ 'String' ],
+            passGeneric: {
+              propertyIndex0: {
+                useGenericIndex0: 'String',
+                useGenericIndex1: [ 'String' ],
+                passGeneric: {
+                  propertyIndex0: 'String',
+                  propertyIndex1: 'String',
+                },
+              },
+              propertyIndex1: 'String',
+            },
+          },
+          generic: [{
+            type: 'com.eggjs.dubbo.ComplexGenericParams',
+            generic: [{
+              type: 'java.lang.String',
+            }, {
+              type: 'java.lang.String',
+            }],
+          }, {
+            type: 'java.lang.String',
+          }],
+        };
+
+        const buf1 = hessian.encode({
+          $class: 'com.eggjs.dubbo.ComplexGenericParams',
+          $: {
+            useGenericIndex0: {
+              $class: 'com.eggjs.dubbo.ComplexGenericParams',
+              $: {
+                useGenericIndex0: 'String',
+                useGenericIndex1: {
+                  $class: 'java.util.List',
+                  $: [ 'String' ],
+                },
+                passGeneric: {
+                  $class: 'com.eggjs.dubbo.PassGeneric',
+                  $: {
+                    propertyIndex0: 'String',
+                    propertyIndex1: 'String',
+                  },
+                },
+              },
+            },
+            useGenericIndex1: {
+              $class: 'java.util.List',
+              $: [ 'String' ],
+            },
+            passGeneric: {
+              $class: 'com.eggjs.dubbo.PassGeneric',
+              $: {
+                propertyIndex0: {
+                  $class: 'com.eggjs.dubbo.ComplexGenericParams',
+                  $: {
+                    useGenericIndex0: 'String',
+                    useGenericIndex1: {
+                      $class: 'java.util.List',
+                      $: [ 'String' ],
+                    },
+                    passGeneric: {
+                      $class: 'com.eggjs.dubbo.PassGeneric',
+                      $: {
+                        propertyIndex0: 'String',
+                        propertyIndex1: 'String',
+                      },
+                    },
+                  },
+                },
+                propertyIndex1: 'String',
+              },
+            },
+          },
+        }, version);
+
+        const buf2 = encode(obj, version, classMap, {}, options);
+        assert.deepEqual(buf1, buf2);
+
+        const buf3 = encode(obj, version, classMap, {}, options);
+        assert.deepEqual(buf1, buf3);
+      });
+
+      it('should support nested and complex pass generic case', () => {
+        const obj = {
+          $class: 'com.eggjs.dubbo.ComplexGenericParams',
+          $: {
+            useGenericIndex0: { // 'ComplexGenericParams<PassGeneric<Float, String>, Boolean>'
+              useGenericIndex0: { // PassGeneric<Float, String>
+                propertyIndex0: 1.11,
+                propertyIndex1: '1.1.2',
+              },
+              useGenericIndex1: [ true ],
+              passGeneric: {
+                propertyIndex0: { // PassGeneric<Float, String>
+                  propertyIndex0: 1.311,
+                  propertyIndex1: '1.3.1.2',
+                },
+                propertyIndex1: true,
+              },
+            },
+            useGenericIndex1: [ 2 ],
+            passGeneric: {
+              propertyIndex0: { // ComplexGenericParams<PassGeneric<Float, String>, Boolean>
+                useGenericIndex0: { // PassGeneric<Float, String>
+                  propertyIndex0: 3.111,
+                  propertyIndex1: '3.1.1.2',
+                },
+                useGenericIndex1: [ false ],
+                passGeneric: {
+                  propertyIndex0: { // PassGeneric<Float, String>
+                    propertyIndex0: 3.1311,
+                    propertyIndex1: '3.1.3.1.2',
+                  },
+                  propertyIndex1: false,
+                },
+              },
+              propertyIndex1: 32,
+            },
+          },
+          generic: [{
+            type: 'com.eggjs.dubbo.ComplexGenericParams',
+            generic: [{
+              type: 'com.eggjs.dubbo.PassGeneric',
+              generic: [{
+                type: 'java.lang.Float',
+              }, {
+                type: 'java.lang.String',
+              }],
+            }, {
+              type: 'java.lang.Boolean',
+            }],
+          }, {
+            type: 'java.lang.Integer',
+          }],
+        };
+
+        const buf1 = hessian.encode({
+          $class: 'com.eggjs.dubbo.ComplexGenericParams',
+          $: {
+            useGenericIndex0: { // 'ComplexGenericParams<PassGeneric<String, String>, String>'
+              $class: 'com.eggjs.dubbo.ComplexGenericParams',
+              $: {
+                useGenericIndex0: { // PassGeneric<String, String>
+                  $class: 'com.eggjs.dubbo.PassGeneric',
+                  $: {
+                    propertyIndex0: 1.11,
+                    propertyIndex1: '1.1.2',
+                  },
+                },
+                useGenericIndex1: {
+                  $class: 'java.util.List',
+                  $: [ true ],
+                },
+                passGeneric: {
+                  $class: 'com.eggjs.dubbo.PassGeneric',
+                  $: {
+                    propertyIndex0: { // PassGeneric<String, String>
+                      $class: 'com.eggjs.dubbo.PassGeneric',
+                      $: {
+                        propertyIndex0: 1.311,
+                        propertyIndex1: '1.3.1.2',
+                      },
+                    },
+                    propertyIndex1: true,
+                  },
+                },
+              },
+            },
+            useGenericIndex1: {
+              $class: 'java.util.List',
+              $: [ 2 ],
+            },
+            passGeneric: {
+              $class: 'com.eggjs.dubbo.PassGeneric',
+              $: {
+                propertyIndex0: { // ComplexGenericParams<PassGeneric<String, String>, String>
+                  $class: 'com.eggjs.dubbo.ComplexGenericParams',
+                  $: {
+                    useGenericIndex0: { // PassGeneric<String, String>
+                      $class: 'com.eggjs.dubbo.PassGeneric',
+                      $: {
+                        propertyIndex0: 3.111,
+                        propertyIndex1: '3.1.1.2',
+                      },
+                    },
+                    useGenericIndex1: {
+                      $class: 'java.util.List',
+                      $: [ false ],
+                    },
+                    passGeneric: {
+                      $class: 'com.eggjs.dubbo.PassGeneric',
+                      $: {
+                        propertyIndex0: { // PassGeneric<String, String>
+                          $class: 'com.eggjs.dubbo.PassGeneric',
+                          $: {
+                            propertyIndex0: 3.1311,
+                            propertyIndex1: '3.1.3.1.2',
+                          },
+                        },
+                        propertyIndex1: false,
+                      },
+                    },
+                  },
+                },
+                propertyIndex1: 32,
+              },
+            },
+          },
+        }, version);
+
+        const buf2 = encode(obj, version, classMap, {}, options);
+        assert.deepEqual(buf1, buf2);
+
+        const buf3 = encode(obj, version, classMap, {}, options);
+        assert.deepEqual(buf1, buf3);
+      });
+
       it('should class inheritance', () => {
         const obj = {
           $class: 'com.alipay.test.Father',


### PR DESCRIPTION
example:

```java
public void method(Model<String, Int> param)


public class Model<T, R> {
  private GenericClazz<T, R> genericProperty;
}

public class GenericClazz<T, R> {
  T property1;
  R property2;
}
```

the classMap should like this, had typeVar filed

```js
{
  'xxx.Model': {
    'genericProperty': {
      'type': 'xxx.GenericClazz',
      'generic': [{
        'typeVar': true,
        'type':'T',
        'typeAliasIndex': 0,
      }, {
        'type':'java.util.List', 
        'generic': [{
          'typeVar': true,
          'type':'R',
          'typeAliasIndex': 1,
        }],
      }],
    },
  },
  'xxx.GenericClazz': {
    'property1': {
      'type': 'T',
      'typeAliasIndex': 0
    },
    'property2': {
      'type': 'R',
      'typeAliasIndex': 1
    },
  },
}
```