### PR TITLE
feat: support custom compileCache

### DIFF
--- a/lib/primitive_type/custom_map.js
+++ b/lib/primitive_type/custom_map.js
@@ -2,7 +2,7 @@
 
 const utils = require('../utils');
 
-module.exports = (gen, classInfo, version, options) => {
+module.exports = (gen, classInfo, version) => {
   gen('if (obj == null) { return encoder.writeNull(); }');
   gen('if (encoder._checkRef(obj)) { return; }');
 
@@ -20,18 +20,18 @@ module.exports = (gen, classInfo, version, options) => {
       const genericValueDefine = utils.normalizeType(generic[1]);
       const keyId = utils.normalizeUniqId(genericKeyDefine, version);
       const valueId = utils.normalizeUniqId(genericValueDefine, version);
-      gen('    const encodeKey = compile(\'%s\', %j, classMap, version, %j); encodeKey(key, encoder, appClassMap);', keyId, genericKeyDefine, options);
-      gen('    const encodeValue = compile(\'%s\', %j, classMap, version, %j); encodeValue(value, encoder, appClassMap);', valueId, genericValueDefine, options);
+      gen('    const encodeKey = compile(\'%s\', %j, classMap, version, options); encodeKey(key, encoder, appClassMap, options);', keyId, genericKeyDefine);
+      gen('    const encodeValue = compile(\'%s\', %j, classMap, version, options); encodeValue(value, encoder, appClassMap, options);', valueId, genericValueDefine);
       gen('  }\n  } else {');
       gen('  for (const key in obj) {');
       gen('    const value = obj[key];');
       const convertor = utils.converts[genericKeyDefine.type];
       if (convertor) {
-        gen('    const encodeKey = compile(\'%s\', %j, classMap, version, %j); encodeKey(%s(key), encoder, appClassMap);', keyId, genericKeyDefine, options, convertor);
+        gen('    const encodeKey = compile(\'%s\', %j, classMap, version, options); encodeKey(%s(key), encoder, appClassMap, options);', keyId, genericKeyDefine, convertor);
       } else {
-        gen('    const encodeKey = compile(\'%s\', %j, classMap, version, %j); encodeKey(key, encoder, appClassMap);', keyId, genericKeyDefine, options);
+        gen('    const encodeKey = compile(\'%s\', %j, classMap, version, options); encodeKey(key, encoder, appClassMap, options);', keyId, genericKeyDefine);
       }
-      gen('    const encodeValue = compile(\'%s\', %j, classMap, version, %j); encodeValue(value, encoder, appClassMap);', valueId, genericValueDefine, options);
+      gen('    const encodeValue = compile(\'%s\', %j, classMap, version, options); encodeValue(value, encoder, appClassMap, options);', valueId, genericValueDefine);
       gen('  }\n  }');
     } else {
       gen('if (obj instanceof Map) {');
@@ -41,7 +41,7 @@ module.exports = (gen, classInfo, version, options) => {
       gen('    encoder.writeString(key);');
       gen('    if (value && value.$class) {');
       gen('      const fnKey = utils.normalizeUniqId(value, version);');
-      gen('      compile(fnKey, value, appClassMap, version, %j)(value.$, encoder);', options);
+      gen('      compile(fnKey, value, appClassMap, version, options)(value.$, encoder, undefined, options);');
       gen('    } else {');
       gen('      encoder.write(value);');
       gen('    }');
@@ -51,7 +51,7 @@ module.exports = (gen, classInfo, version, options) => {
       gen('    encoder.writeString(key);');
       gen('    if (value && value.$class) {');
       gen('      const fnKey = utils.normalizeUniqId(value, version);');
-      gen('      compile(fnKey, value, appClassMap, version, %j)(value.$, encoder);', options);
+      gen('      compile(fnKey, value, appClassMap, version, options)(value.$, encoder, undefined, options);');
       gen('    } else {');
       gen('      encoder.write(value);');
       gen('    }');
@@ -70,12 +70,12 @@ module.exports = (gen, classInfo, version, options) => {
       gen('  if (ref === -1) {');
       gen('    encoder.writeInt(keys.length);');
       gen('    for (const key of keys) {');
-      gen('      const encodeKey = compile(\'%s\', %j, classMap, version, %j); encodeKey(key, encoder, appClassMap);', keyId, genericKeyDefine, options);
+      gen('      const encodeKey = compile(\'%s\', %j, classMap, version, options); encodeKey(key, encoder, appClassMap, options);', keyId, genericKeyDefine);
       gen('    }');
       gen('    encoder._writeObjectBegin(\'%s\');', classInfo.type);
       gen('  }');
       gen('  for (const value of obj.values()) {');
-      gen('    const encodeValue = compile(\'%s\', %j, classMap, version, %j); encodeValue(value, encoder, appClassMap);', valueId, genericValueDefine, options);
+      gen('    const encodeValue = compile(\'%s\', %j, classMap, version, options); encodeValue(value, encoder, appClassMap, options);', valueId, genericValueDefine);
       gen('  }');
       gen('} else {');
       gen('  if (ref === -1) {');
@@ -83,16 +83,16 @@ module.exports = (gen, classInfo, version, options) => {
       gen('    for (const key of keys) {');
       const convertor = utils.converts[genericKeyDefine.type];
       if (convertor) {
-        gen('      const encodeKey = compile(\'%s\', %j, classMap, version, %j); encodeKey(%s(key), encoder, appClassMap);', keyId, genericKeyDefine, options, convertor);
+        gen('      const encodeKey = compile(\'%s\', %j, classMap, version, options); encodeKey(%s(key), encoder, appClassMap, options);', keyId, genericKeyDefine, convertor);
       } else {
-        gen('      const encodeKey = compile(\'%s\', %j, classMap, version, %j); encodeKey(key, encoder, appClassMap);', keyId, genericKeyDefine, options);
+        gen('      const encodeKey = compile(\'%s\', %j, classMap, version, options); encodeKey(key, encoder, appClassMap, options);', keyId, genericKeyDefine);
       }
       gen('    encoder._writeObjectBegin(\'%s\');', classInfo.type);
       gen('    }');
       gen('  }');
       gen('  for (const key of keys) {');
       gen('    const value = obj[key];');
-      gen('    const encodeValue = compile(\'%s\', %j, classMap, version, %j); encodeValue(value, encoder, appClassMap);', valueId, genericValueDefine, options);
+      gen('    const encodeValue = compile(\'%s\', %j, classMap, version, options); encodeValue(value, encoder, appClassMap, options);', valueId, genericValueDefine);
       gen('  }');
       gen('}');
     } else {
@@ -107,7 +107,7 @@ module.exports = (gen, classInfo, version, options) => {
       gen('  for (const value of obj.values()) {');
       gen('    if (value && value.$class) {');
       gen('      const fnKey = utils.normalizeUniqId(value, version);');
-      gen('      compile(fnKey, value, appClassMap, version, %j)(value.$, encoder);', options);
+      gen('      compile(fnKey, value, appClassMap, version, options)(value.$, encoder, undefined, options);');
       gen('    } else {');
       gen('      encoder.write(value);');
       gen('    }');
@@ -124,7 +124,7 @@ module.exports = (gen, classInfo, version, options) => {
       gen('    const value = obj[key];');
       gen('    if (value && value.$class) {');
       gen('      const fnKey = utils.normalizeUniqId(value, version);');
-      gen('      compile(fnKey, value, appClassMap, version, %j)(value.$, encoder);', options);
+      gen('      compile(fnKey, value, appClassMap, version, options)(value.$, encoder, undefined, options);');
       gen('    } else {');
       gen('      encoder.write(value);');
       gen('    }');

--- a/lib/primitive_type/java.lang.exception.js
+++ b/lib/primitive_type/java.lang.exception.js
@@ -2,7 +2,7 @@
 
 const utils = require('../utils');
 
-module.exports = (gen, classInfo, version, options) => {
+module.exports = (gen, classInfo, version) => {
   gen('if (obj && obj.$class) { obj = obj.$; }');
   gen('if (obj == null) { return encoder.writeNull(); }');
 
@@ -53,7 +53,7 @@ module.exports = (gen, classInfo, version, options) => {
       gen('encoder.writeString(\'%s\');', key);
       const attr = classInfo[key];
       const uniqueId = utils.normalizeUniqId(attr, version);
-      gen('compile(\'%s\', %j, classMap, version, %j)(obj[\'%s\'], encoder);', uniqueId, attr, options, key);
+      gen('compile(\'%s\', %j, classMap, version, options)(obj[\'%s\'], encoder, undefined, options);', uniqueId, attr, key);
     }
     gen('encoder.byteBuffer.put(0x7a);');
   } else {
@@ -68,7 +68,7 @@ module.exports = (gen, classInfo, version, options) => {
     for (const key of keys) {
       const attr = classInfo[key];
       const uniqueId = utils.normalizeUniqId(attr, version);
-      gen('compile(\'%s\', %j, classMap, version, %j)(obj[\'%s\'], encoder);', uniqueId, attr, options, key);
+      gen('compile(\'%s\', %j, classMap, version, options)(obj[\'%s\'], encoder, undefined, options);', uniqueId, attr, key);
     }
   }
 };

--- a/lib/primitive_type/java.lang.object.js
+++ b/lib/primitive_type/java.lang.object.js
@@ -1,10 +1,10 @@
 'use strict';
 
-module.exports = (gen, classInfo, version, options) => {
+module.exports = gen => {
   gen('if (obj == null) { return encoder.writeNull(); }');
   gen('if (obj && obj.$class) {');
   gen('  const fnKey = utils.normalizeUniqId(obj, version);');
-  gen('  compile(fnKey, obj, appClassMap, version, %j)(obj.$, encoder);', options);
+  gen('  compile(fnKey, obj, appClassMap, version, options)(obj.$, encoder, undefined, options);');
   gen('} else {');
   gen('  encoder.write(obj);');
   gen('}');

--- a/lib/primitive_type/java.lang.stacktraceelement.js
+++ b/lib/primitive_type/java.lang.stacktraceelement.js
@@ -2,7 +2,7 @@
 
 const utils = require('../utils');
 
-module.exports = (gen, classInfo, version, options) => {
+module.exports = (gen, classInfo, version) => {
   gen('if (obj && obj.$class) { obj = obj.$; }');
   gen('if (obj == null) { return encoder.writeNull(); }');
   gen('if (encoder._checkRef(obj)) { return; }');
@@ -30,7 +30,7 @@ module.exports = (gen, classInfo, version, options) => {
       gen('encoder.writeString(\'%s\');', key);
       const attr = classInfo[key];
       const uniqueId = utils.normalizeUniqId(attr, version);
-      gen('compile(\'%s\', %j, classMap, version, %j)(obj[\'%s\'], encoder);', uniqueId, attr, options, key);
+      gen('compile(\'%s\', %j, classMap, version, options)(obj[\'%s\'], encoder, undefined, options);', uniqueId, attr, key);
     }
     gen('encoder.byteBuffer.put(0x7a);');
   } else {
@@ -45,7 +45,7 @@ module.exports = (gen, classInfo, version, options) => {
     for (const key of keys) {
       const attr = classInfo[key];
       const uniqueId = utils.normalizeUniqId(attr, version);
-      gen('compile(\'%s\', %j, classMap, version, %j)(obj[\'%s\'], encoder);', uniqueId, attr, options, key);
+      gen('compile(\'%s\', %j, classMap, version, options)(obj[\'%s\'], encoder, undefined, options);', uniqueId, attr, key);
     }
   }
 };

--- a/lib/primitive_type/java.util.arraylist.js
+++ b/lib/primitive_type/java.util.arraylist.js
@@ -2,7 +2,7 @@
 
 const utils = require('../utils');
 
-module.exports = (gen, classInfo, version, options) => {
+module.exports = (gen, classInfo, version) => {
   gen('if (obj && obj.$class) { obj = obj.$; }');
   gen('if (obj == null) { return encoder.writeNull(); }');
   gen('if (encoder._checkRef(obj)) { return; }');
@@ -20,7 +20,7 @@ module.exports = (gen, classInfo, version, options) => {
     gen('  } else {');
     gen('    desc = %j;', genericDefine);
     gen('  }');
-    gen('  compile(\'%s\', desc, classMap, version, %j)(item, encoder, appClassMap);', uniqueId, options);
+    gen('  compile(\'%s\', desc, classMap, version, options)(item, encoder, appClassMap, options);', uniqueId);
     gen('}');
   } else {
     gen('for (const item of obj) { encoder.write(item); }');

--- a/lib/primitive_type/java.util.concurrent.atomic.atomiclong.js
+++ b/lib/primitive_type/java.util.concurrent.atomic.atomiclong.js
@@ -2,7 +2,7 @@
 
 const utils = require('../utils');
 
-module.exports = (gen, classInfo, version, options) => {
+module.exports = (gen, classInfo, version) => {
   gen('if (obj && obj.$class) { obj = obj.$; }');
   gen('if (obj == null) { return encoder.writeNull(); }');
   gen('if (encoder._checkRef(obj)) { return; }');
@@ -17,7 +17,7 @@ module.exports = (gen, classInfo, version, options) => {
     gen('encoder.byteBuffer.put(0x4d);');
     gen('encoder.writeType(\'java.util.concurrent.atomic.AtomicLong\');');
     gen('encoder.writeString(\'value\');');
-    gen('compile(\'%s\', %j, classMap, version, %j)(obj, encoder);', uniqueId, attr, options);
+    gen('compile(\'%s\', %j, classMap, version, options)(obj, encoder, undefined, options);', uniqueId, attr);
     gen('encoder.byteBuffer.put(0x7a);');
   } else {
     gen('const ref = encoder._writeObjectBegin(\'java.util.concurrent.atomic.AtomicLong\');');
@@ -25,6 +25,6 @@ module.exports = (gen, classInfo, version, options) => {
     gen('encoder.writeInt(1);');
     gen('encoder.writeString(\'value\');');
     gen('encoder._writeObjectBegin(\'java.util.concurrent.atomic.AtomicLong\'); }');
-    gen('compile(\'%s\', %j, classMap, version, %j)(obj, encoder);', uniqueId, attr, options);
+    gen('compile(\'%s\', %j, classMap, version, options)(obj, encoder, undefined, options);', uniqueId, attr);
   }
 };

--- a/lib/primitive_type/java.util.list.js
+++ b/lib/primitive_type/java.util.list.js
@@ -2,7 +2,7 @@
 
 const utils = require('../utils');
 
-module.exports = (gen, classInfo, version, options) => {
+module.exports = (gen, classInfo, version) => {
   gen('if (obj && obj.$class) { obj = obj.$; }');
   gen('if (obj == null) { return encoder.writeNull(); }');
   gen('if (encoder._checkRef(obj)) { return; }');
@@ -35,7 +35,7 @@ module.exports = (gen, classInfo, version, options) => {
     gen('  } else {');
     gen('   desc = %j;', genericDefine);
     gen('  }');
-    gen('  compile(uniqueId, desc, classMap, version, %j)(val, encoder, appClassMap);', options);
+    gen('  compile(uniqueId, desc, classMap, version, options)(val, encoder, appClassMap, options);');
     gen('}');
   } else {
     gen('for (const item of obj) { encoder.write(item); }');

--- a/lib/primitive_type/java.util.map.js
+++ b/lib/primitive_type/java.util.map.js
@@ -2,7 +2,7 @@
 
 const utils = require('../utils');
 
-module.exports = (gen, classInfo, version, options) => {
+module.exports = (gen, classInfo, version) => {
   gen('if (obj && obj.$class) { obj = obj.$; }');
   gen('if (obj == null) { return encoder.writeNull(); }');
   gen('if (encoder._checkRef(obj)) { return; }');
@@ -24,18 +24,18 @@ module.exports = (gen, classInfo, version, options) => {
     const genericValueDefine = utils.normalizeType(generic[1]);
     const keyId = utils.normalizeUniqId(genericKeyDefine, version);
     const valueId = utils.normalizeUniqId(genericValueDefine, version);
-    gen('    const encodeKey = compile(\'%s\', %j, classMap, version, %j); encodeKey(key, encoder, appClassMap);', keyId, genericKeyDefine, options);
-    gen('    const encodeValue = compile(\'%s\', %j, classMap, version, %j); encodeValue(value, encoder, appClassMap);', valueId, genericValueDefine, options);
+    gen('    const encodeKey = compile(\'%s\', %j, classMap, version, options); encodeKey(key, encoder, appClassMap, options);', keyId, genericKeyDefine);
+    gen('    const encodeValue = compile(\'%s\', %j, classMap, version, options); encodeValue(value, encoder, appClassMap, options);', valueId, genericValueDefine);
     gen('  }\n  } else {');
     gen('  for (const key in obj) {');
     gen('    const value = obj[key];');
     const convertor = utils.converts[genericKeyDefine.type];
     if (convertor) {
-      gen('    const encodeKey = compile(\'%s\', %j, classMap, version, %j); encodeKey(%s(key), encoder, appClassMap);', keyId, genericKeyDefine, options, convertor);
+      gen('    const encodeKey = compile(\'%s\', %j, classMap, version, options); encodeKey(%s(key), encoder, appClassMap, options);', keyId, genericKeyDefine, convertor);
     } else {
-      gen('    const encodeKey = compile(\'%s\', %j, classMap, version, %j); encodeKey(key, encoder, appClassMap);', keyId, genericKeyDefine, options);
+      gen('    const encodeKey = compile(\'%s\', %j, classMap, version, options); encodeKey(key, encoder, appClassMap, options);', keyId, genericKeyDefine);
     }
-    gen('    const encodeValue = compile(\'%s\', %j, classMap, version, %j); encodeValue(value, encoder, appClassMap);', valueId, genericValueDefine, options);
+    gen('    const encodeValue = compile(\'%s\', %j, classMap, version, options); encodeValue(value, encoder, appClassMap, options);', valueId, genericValueDefine);
     gen('  }\n  }');
   } else {
     gen('if (obj instanceof Map) {');
@@ -45,7 +45,7 @@ module.exports = (gen, classInfo, version, options) => {
     gen('    encoder.writeString(key);');
     gen('    if (value && value.$class) {');
     gen('      const fnKey = utils.normalizeUniqId(value, version);');
-    gen('      compile(fnKey, value, appClassMap, version, %j)(value.$, encoder);', options);
+    gen('      compile(fnKey, value, appClassMap, version, options)(value.$, encoder, undefined, options);');
     gen('    } else {');
     gen('      encoder.write(value);');
     gen('    }');
@@ -55,7 +55,7 @@ module.exports = (gen, classInfo, version, options) => {
     gen('    encoder.writeString(key);');
     gen('    if (value && value.$class) {');
     gen('      const fnKey = utils.normalizeUniqId(value, version);');
-    gen('      compile(fnKey, value, appClassMap, version, %j)(value.$, encoder);', options);
+    gen('      compile(fnKey, value, appClassMap, version, options)(value.$, encoder, undefined, options);');
     gen('    } else {');
     gen('      encoder.write(value);');
     gen('    }');

--- a/lib/v3/compile.js
+++ b/lib/v3/compile.js
@@ -74,7 +74,7 @@ module.exports = (info, version, classMap, options = {}) => {
   return compile(uniqueId, info, classMap, version, options);
 };
 
-function compileProp(gen, info, key, classInfo, version, options) {
+function compileProp(gen, info, key, classInfo, version) {
   const attr = Object.create(null, Object.getOwnPropertyDescriptors(classInfo[key]));
 
   // generic param pass handle
@@ -96,11 +96,11 @@ function compileProp(gen, info, key, classInfo, version, options) {
   const uniqueId = utils.normalizeUniqId(attr, version);
   const desc = Object.getOwnPropertyDescriptor(attr, 'defaultValue');
   if (!desc) {
-    gen('compile(\'%s\', %j, classMap, version, %j)(obj[\'%s\'], encoder, appClassMap);', uniqueId, attr, options, key);
+    gen('compile(\'%s\', %j, classMap, version, options)(obj[\'%s\'], encoder, appClassMap, options);', uniqueId, attr, key);
   } else {
     Object.defineProperty(attr, 'defaultValue', Object.assign({}, desc, { enumerable: false }));
     const dv = desc.get ? `({ ${utils.getterStringify(desc.get)} }).defaultValue` : JSON.stringify(desc.value);
-    gen('compile(\'%s\', %j, classMap, version, %j)(utils.has(obj, \'%s\') ? obj[\'%s\'] : %s, encoder, appClassMap);', uniqueId, attr, options, key, key, dv);
+    gen('compile(\'%s\', %j, classMap, version, options)(utils.has(obj, \'%s\') ? obj[\'%s\'] : %s, encoder, appClassMap, options);', uniqueId, attr, key, key, dv);
   }
 }
 
@@ -122,14 +122,15 @@ function parseGenericTypeVar(generic, info) {
 }
 
 function compile(uniqueId, info, classMap, version, options) {
-  let encodeFn = cache.get(uniqueId);
+  const compileCache = (options.compileCache && options.compileCache.get) ? options.compileCache : cache;
+  let encodeFn = compileCache.get(uniqueId);
   if (encodeFn) return encodeFn;
 
   const type = info.type || info.$class;
   // 先获取 classInfo，因为 type 后面会变
   const classInfo = classMap && classMap[type];
 
-  const gen = codegen([ 'obj', 'encoder', 'appClassMap' ], 'encode');
+  const gen = codegen([ 'obj', 'encoder', 'appClassMap', `options = ${JSON.stringify(options)}` ], 'encode');
   if (info.isArray) {
     gen('if (obj == null) { return encoder.writeNull(); }');
     const arrayDepth = info.arrayDepth || 1;
@@ -159,7 +160,7 @@ function compile(uniqueId, info, classMap, version, options) {
       };
       const uniqueId = utils.normalizeUniqId(item, version);
       gen('for (const item of obj) {');
-      gen('  compile(\'%s\', %j, classMap, version, %j)(item, encoder, appClassMap);', uniqueId, item, options);
+      gen('  compile(\'%s\', %j, classMap, version, options)(item, encoder, appClassMap, options);', uniqueId, item);
       gen('}');
       gen('if (hasEnd) { encoder.byteBuffer.putChar(\'z\'); }');
     }
@@ -198,7 +199,7 @@ function compile(uniqueId, info, classMap, version, options) {
     gen('if (obj == null) { return encoder.writeNull(); }');
     gen('if (obj && obj.$class) {');
     gen('  const fnKey = utils.normalizeUniqId(obj, version);');
-    gen('  compile(fnKey, obj, classMap, version, %j)(obj.$, encoder, appClassMap);', options);
+    gen('  compile(fnKey, obj, classMap, version, options)(obj.$, encoder, appClassMap, options);');
     gen('  return;');
     gen('}');
     gen('if (encoder._checkRef(obj)) { return; }');
@@ -233,7 +234,7 @@ function compile(uniqueId, info, classMap, version, options) {
     gen('if (obj == null) { return encoder.writeNull(); }');
     gen('if (obj && obj.$class) {');
     gen('  const fnKey = utils.normalizeUniqId(obj, version);');
-    gen('  compile(fnKey, obj, classMap, version, %j)(obj.$, encoder, appClassMap);', options);
+    gen('  compile(fnKey, obj, classMap, version, options)(obj.$, encoder, appClassMap, options);');
     gen('}');
     gen('else { encoder.write({ $class: \'%s\', $: obj }); }', type);
   }
@@ -250,7 +251,7 @@ module.exports = function (compile, classMap, version, utils) {
     fs.writeFileSync(jsFile, func);
     encodeFn = require(jsFile)(compile, classMap, version, utils);
   }
-  cache.set(uniqueId, encodeFn);
+  compileCache.set(uniqueId, encodeFn);
   return encodeFn;
 }
 

--- a/lib/v3/index.js
+++ b/lib/v3/index.js
@@ -11,7 +11,7 @@ exports.encode = (obj, version, classMap, appClassMap, options) => {
   const encoder = version === '2.0' ? encoderV2 : encoderV1;
   encoder.reset();
   if (classMap) {
-    compile(obj, version, classMap, options)(obj.$, encoder, appClassMap);
+    compile(obj, version, classMap, options)(obj.$, encoder, appClassMap, options);
   } else {
     encoder.write(obj);
   }

--- a/lib/v4/compile.js
+++ b/lib/v4/compile.js
@@ -73,7 +73,7 @@ module.exports = (info, version, classMap, options = {}) => {
   return compile(uniqueId, info, classMap, version, options);
 };
 
-function compileProp(gen, info, key, classInfo, version, options) {
+function compileProp(gen, info, key, classInfo, version) {
   const attr = Object.create(null, Object.getOwnPropertyDescriptors(classInfo[key]));
 
   // generic param pass handle
@@ -95,11 +95,11 @@ function compileProp(gen, info, key, classInfo, version, options) {
   const uniqueId = utils.normalizeUniqId(attr, version);
   const desc = Object.getOwnPropertyDescriptor(attr, 'defaultValue');
   if (!desc) {
-    gen('compile(\'%s\', %j, classMap, version, %j)(obj[\'%s\'], encoder, appClassMap);', uniqueId, attr, options, key);
+    gen('compile(\'%s\', %j, classMap, version, options)(obj[\'%s\'], encoder, appClassMap, options);', uniqueId, attr, key);
   } else {
     Object.defineProperty(attr, 'defaultValue', Object.assign({}, desc, { enumerable: false }));
     const dv = desc.get ? `({ ${utils.getterStringify(desc.get)} }).defaultValue` : JSON.stringify(desc.value);
-    gen('compile(\'%s\', %j, classMap, version, %j)(utils.has(obj, \'%s\') ? obj[\'%s\'] : %s, encoder, appClassMap);', uniqueId, attr, options, key, key, dv);
+    gen('compile(\'%s\', %j, classMap, version, options)(utils.has(obj, \'%s\') ? obj[\'%s\'] : %s, encoder, appClassMap, options);', uniqueId, attr, key, key, dv);
   }
 }
 
@@ -121,14 +121,15 @@ function parseGenericTypeVar(generic, info) {
 }
 
 function compile(uniqueId, info, classMap, version, options) {
-  let encodeFn = cache.get(uniqueId);
+  const compileCache = (options.compileCache && options.compileCache.get) ? options.compileCache : cache;
+  let encodeFn = compileCache.get(uniqueId);
   if (encodeFn) return encodeFn;
 
   const type = info.type || info.$class;
   // 先获取 classInfo，因为 type 后面会变
   const classInfo = classMap && classMap[type];
 
-  const gen = codegen([ 'obj', 'encoder', 'appClassMap' ], 'encode');
+  const gen = codegen([ 'obj', 'encoder', 'appClassMap', `options = ${JSON.stringify(options)}` ], 'encode');
   // 默认值
   if (info.defaultValue) {
     gen('if (obj == null) { obj = %j; }', info.defaultValue);
@@ -162,7 +163,7 @@ function compile(uniqueId, info, classMap, version, options) {
       };
       const uniqueId = utils.normalizeUniqId(item, version);
       gen('for (const item of obj) {');
-      gen('  compile(\'%s\', %j, classMap, version, %j)(item && item.$class ? item.$ : item, encoder, appClassMap);', uniqueId, item, options);
+      gen('  compile(\'%s\', %j, classMap, version, options)(item && item.$class ? item.$ : item, encoder, appClassMap, options);', uniqueId, item);
       gen('}');
       gen('if (hasEnd) { encoder.byteBuffer.putChar(\'z\'); }');
     }
@@ -174,7 +175,7 @@ function compile(uniqueId, info, classMap, version, options) {
     gen('if (obj == null) { return encoder.writeNull(); }');
     gen('if (obj && obj.$class) {');
     gen('  const fnKey = utils.normalizeUniqId(obj, version);');
-    gen('  compile(fnKey, obj, classMap, version, %j)(obj.$, encoder, appClassMap);', options);
+    gen('  compile(fnKey, obj, classMap, version, options)(obj.$, encoder, appClassMap, options);');
     gen('  return;');
     gen('}');
     gen('if (encoder._checkRef(obj)) { return; }');
@@ -228,7 +229,7 @@ function compile(uniqueId, info, classMap, version, options) {
     gen('if (obj == null) { return encoder.writeNull(); }');
     gen('if (obj && obj.$class) {');
     gen('  const fnKey = utils.normalizeUniqId(obj, version);');
-    gen('  compile(fnKey, obj, classMap, version, %j)(obj.$, encoder, appClassMap);', options);
+    gen('  compile(fnKey, obj, classMap, version, options)(obj.$, encoder, appClassMap, options);');
     gen('}');
     gen('else { encoder.write({ $class: \'%s\', $: obj }); }', type);
   }
@@ -245,7 +246,7 @@ module.exports = function (compile, classMap, version, utils) {
     fs.writeFileSync(jsFile, func);
     encodeFn = require(jsFile)(compile, classMap, version, utils);
   }
-  cache.set(uniqueId, encodeFn);
+  compileCache.set(uniqueId, encodeFn);
   return encodeFn;
 }
 

--- a/lib/v4/index.js
+++ b/lib/v4/index.js
@@ -11,7 +11,7 @@ exports.encode = (obj, version, classMap, appClassMap, options) => {
   const encoder = version === '2.0' ? encoderV2 : encoderV1;
   encoder.reset();
   if (classMap) {
-    compile(obj, version, classMap, options)(obj.$, encoder, appClassMap);
+    compile(obj, version, classMap, options)(obj.$, encoder, appClassMap, options);
   } else {
     encoder.write(obj);
   }

--- a/lib/v4/type/java.util.map.js
+++ b/lib/v4/type/java.util.map.js
@@ -2,7 +2,7 @@
 
 const utils = require('../../utils');
 
-module.exports = (gen, classInfo, version, options) => {
+module.exports = (gen, classInfo, version) => {
   gen('if (obj == null) { return encoder.writeNull(); }');
   gen('if (encoder._checkRef(obj)) { return; }');
 
@@ -27,18 +27,18 @@ module.exports = (gen, classInfo, version, options) => {
     const genericValueDefine = utils.normalizeType(generic[1]);
     const keyId = utils.normalizeUniqId(genericKeyDefine, version);
     const valueId = utils.normalizeUniqId(genericValueDefine, version);
-    gen('    const encodeKey = compile(\'%s\', %j, classMap, version, %j); encodeKey(key, encoder, appClassMap);', keyId, genericKeyDefine, options);
-    gen('    const encodeValue = compile(\'%s\', %j, classMap, version, %j); encodeValue(value, encoder, appClassMap);', valueId, genericValueDefine, options);
+    gen('    const encodeKey = compile(\'%s\', %j, classMap, version, options); encodeKey(key, encoder, appClassMap, options);', keyId, genericKeyDefine);
+    gen('    const encodeValue = compile(\'%s\', %j, classMap, version, options); encodeValue(value, encoder, appClassMap, options);', valueId, genericValueDefine);
     gen('  }\n  } else {');
     gen('  for (const key in obj) {');
     gen('    const value = obj[key];');
     const convertor = utils.converts[genericKeyDefine.type];
     if (convertor) {
-      gen('    const encodeKey = compile(\'%s\', %j, classMap, version, %j); encodeKey(%s(key), encoder, appClassMap);', keyId, genericKeyDefine, options, convertor);
+      gen('    const encodeKey = compile(\'%s\', %j, classMap, version, options); encodeKey(%s(key), encoder, appClassMap, options);', keyId, genericKeyDefine, convertor);
     } else {
-      gen('    const encodeKey = compile(\'%s\', %j, classMap, version, %j); encodeKey(key, encoder, appClassMap);', keyId, genericKeyDefine, options);
+      gen('    const encodeKey = compile(\'%s\', %j, classMap, version, options); encodeKey(key, encoder, appClassMap, options);', keyId, genericKeyDefine);
     }
-    gen('    const encodeValue = compile(\'%s\', %j, classMap, version, %j); encodeValue(value, encoder, appClassMap);', valueId, genericValueDefine, options);
+    gen('    const encodeValue = compile(\'%s\', %j, classMap, version, options); encodeValue(value, encoder, appClassMap, options);', valueId, genericValueDefine);
     gen('  }\n  }');
   } else {
     gen('if (obj instanceof Map) {');
@@ -48,7 +48,7 @@ module.exports = (gen, classInfo, version, options) => {
     gen('    encoder.writeString(key);');
     gen('    if (value && value.$class) {');
     gen('      const fnKey = utils.normalizeUniqId(value, version);');
-    gen('      compile(fnKey, value, appClassMap, version, %j)(value.$, encoder);', options);
+    gen('      compile(fnKey, value, appClassMap, version, options)(value.$, encoder, undefined, options);');
     gen('    } else {');
     gen('      encoder.write(value);');
     gen('    }');
@@ -58,7 +58,7 @@ module.exports = (gen, classInfo, version, options) => {
     gen('    encoder.writeString(key);');
     gen('    if (value && value.$class) {');
     gen('      const fnKey = utils.normalizeUniqId(value, version);');
-    gen('      compile(fnKey, value, appClassMap, version, %j)(value.$, encoder);', options);
+    gen('      compile(fnKey, value, appClassMap, version, options)(value.$, encoder, undefined, options);');
     gen('    } else {');
     gen('      encoder.write(value);');
     gen('    }');

--- a/test/compile.test.js
+++ b/test/compile.test.js
@@ -32,4 +32,21 @@ describe('test/compile.test.js', () => {
     // recover
     compile.setCache(new Map());
   });
+
+  it('should compile compileCache work', () => {
+    const compileCache = { get: () => { throw new Error('mock error'); }, set: () => {} };
+
+    try {
+      encode({
+        $class: 'java.util.Map',
+        $: { foo: 'bar' },
+        isMap: true,
+      }, '2.0', {}, {}, {
+        compileCache,
+      });
+      assert(false, 'never here');
+    } catch (err) {
+      assert(err.message === 'mock error');
+    }
+  });
 });


### PR DESCRIPTION
需求点:
支持配置自定义预编译缓存存储对象

解决方式：
1. compile入口options支持配置自定义预编译缓存
2. options作为引用透传到encode预编译函数中，便于后期扩展

框架测试点
test/compile.test.js
it('should compile compileCache work')
