### PR TITLE
feat: support custom compileCache

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -25,7 +25,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm i -g npminstall && npminstall
+    - run: npm i
     - run: npm run ci
       env:
         CI: true

--- a/lib/v3/compile.js
+++ b/lib/v3/compile.js
@@ -123,17 +123,18 @@ function parseGenericTypeVar(generic, info) {
 }
 
 /**
- * 根据special key来区分Map层级逻辑
- * @param {*} classMap classMap
+ * special key to determine the map structure logic
+ * @param {Map<string, object>} classMap class data required for compile
  */
 function getCompileCache(classMap) {
-  if (cache.get(classMapCacheOn)) {
-    if (!cache.has(classMap)) {
-      cache.set(classMap, new Map());
-    }
-    return cache.get(classMap);
+  if (!cache.get(classMapCacheOn)) {
+    return cache;
   }
-  return cache;
+  // If there is a special key, the cache uses the classmap dimension to establish a secondary cache structure. Different classmaps use different caches
+  if (!cache.has(classMap)) {
+    cache.set(classMap, new Map());
+  }
+  return cache.get(classMap);
 }
 
 function compile(uniqueId, info, classMap, version, options) {

--- a/lib/v3/compile.js
+++ b/lib/v3/compile.js
@@ -7,7 +7,7 @@ const utils = require('../utils');
 const has = require('utility').has;
 const codegen = require('@protobufjs/codegen');
 
-let cacheWeakMap = new WeakMap();
+let cache = new Map();
 const typeMap = {
   bool: require('../primitive_type/boolean'),
   boolean: require('../primitive_type/boolean'),
@@ -122,10 +122,7 @@ function parseGenericTypeVar(generic, info) {
 }
 
 function compile(uniqueId, info, classMap, version, options) {
-  if (!cacheWeakMap.has(classMap)) {
-    cacheWeakMap.set(classMap, new Map());
-  }
-  const compileCache = cacheWeakMap.get(classMap);
+  const compileCache = classMap && classMap.$compileCache || cache;
   let encodeFn = compileCache.get(uniqueId);
   if (encodeFn) return encodeFn;
 
@@ -258,12 +255,12 @@ module.exports = function (compile, classMap, version, utils) {
   return encodeFn;
 }
 
-module.exports.cache = cacheWeakMap;
+module.exports.cache = cache;
 
 // for special use, don't do this unless you know what u'r doing
 module.exports.setCache = function(newCache) {
-  cacheWeakMap = newCache;
+  cache = newCache;
 };
 module.exports.getCache = function() {
-  return cacheWeakMap;
+  return cache;
 };

--- a/lib/v3/compile.js
+++ b/lib/v3/compile.js
@@ -6,6 +6,7 @@ const assert = require('assert');
 const utils = require('../utils');
 const has = require('utility').has;
 const codegen = require('@protobufjs/codegen');
+const classMapCacheOn = Symbol('classMapCacheOn');
 
 let cache = new Map();
 const typeMap = {
@@ -121,8 +122,22 @@ function parseGenericTypeVar(generic, info) {
   return newGeneric;
 }
 
+/**
+ * 根据special key来区分Map层级逻辑
+ * @param {*} classMap classMap
+ */
+function getCompileCache(classMap) {
+  if (cache.get(classMapCacheOn)) {
+    if (!cache.has(classMap)) {
+      cache.set(classMap, new Map());
+    }
+    return cache.get(classMap);
+  }
+  return cache;
+}
+
 function compile(uniqueId, info, classMap, version, options) {
-  const compileCache = classMap && classMap.$compileCache || cache;
+  const compileCache = getCompileCache(classMap);
   let encodeFn = compileCache.get(uniqueId);
   if (encodeFn) return encodeFn;
 
@@ -264,3 +279,5 @@ module.exports.setCache = function(newCache) {
 module.exports.getCache = function() {
   return cache;
 };
+
+module.exports.classMapCacheOn = classMapCacheOn;

--- a/lib/v3/compile.js
+++ b/lib/v3/compile.js
@@ -122,7 +122,8 @@ function parseGenericTypeVar(generic, info) {
 }
 
 function compile(uniqueId, info, classMap, version, options) {
-  let encodeFn = cache.get(uniqueId);
+  const compileCache = classMap && classMap.compileCache || cache;
+  let encodeFn = compileCache.get(uniqueId);
   if (encodeFn) return encodeFn;
 
   const type = info.type || info.$class;
@@ -250,7 +251,7 @@ module.exports = function (compile, classMap, version, utils) {
     fs.writeFileSync(jsFile, func);
     encodeFn = require(jsFile)(compile, classMap, version, utils);
   }
-  cache.set(uniqueId, encodeFn);
+  compileCache.set(uniqueId, encodeFn);
   return encodeFn;
 }
 

--- a/lib/v3/compile.js
+++ b/lib/v3/compile.js
@@ -122,7 +122,7 @@ function parseGenericTypeVar(generic, info) {
 }
 
 function compile(uniqueId, info, classMap, version, options) {
-  const compileCache = classMap && classMap.compileCache || cache;
+  const compileCache = classMap && classMap.$compileCache || cache;
   let encodeFn = compileCache.get(uniqueId);
   if (encodeFn) return encodeFn;
 

--- a/lib/v3/compile.js
+++ b/lib/v3/compile.js
@@ -7,7 +7,7 @@ const utils = require('../utils');
 const has = require('utility').has;
 const codegen = require('@protobufjs/codegen');
 
-let cache = new Map();
+let cacheWeakMap = new WeakMap();
 const typeMap = {
   bool: require('../primitive_type/boolean'),
   boolean: require('../primitive_type/boolean'),
@@ -122,7 +122,10 @@ function parseGenericTypeVar(generic, info) {
 }
 
 function compile(uniqueId, info, classMap, version, options) {
-  const compileCache = classMap && classMap.$compileCache || cache;
+  if (!cacheWeakMap.has(classMap)) {
+    cacheWeakMap.set(classMap, new Map());
+  }
+  const compileCache = cacheWeakMap.get(classMap);
   let encodeFn = compileCache.get(uniqueId);
   if (encodeFn) return encodeFn;
 
@@ -255,12 +258,12 @@ module.exports = function (compile, classMap, version, utils) {
   return encodeFn;
 }
 
-module.exports.cache = cache;
+module.exports.cache = cacheWeakMap;
 
 // for special use, don't do this unless you know what u'r doing
 module.exports.setCache = function(newCache) {
-  cache = newCache;
+  cacheWeakMap = newCache;
 };
 module.exports.getCache = function() {
-  return cache;
+  return cacheWeakMap;
 };

--- a/lib/v4/compile.js
+++ b/lib/v4/compile.js
@@ -121,7 +121,8 @@ function parseGenericTypeVar(generic, info) {
 }
 
 function compile(uniqueId, info, classMap, version, options) {
-  let encodeFn = cache.get(uniqueId);
+  const compileCache = classMap && classMap.compileCache || cache;
+  let encodeFn = compileCache.get(uniqueId);
   if (encodeFn) return encodeFn;
 
   const type = info.type || info.$class;
@@ -245,7 +246,7 @@ module.exports = function (compile, classMap, version, utils) {
     fs.writeFileSync(jsFile, func);
     encodeFn = require(jsFile)(compile, classMap, version, utils);
   }
-  cache.set(uniqueId, encodeFn);
+  compileCache.set(uniqueId, encodeFn);
   return encodeFn;
 }
 

--- a/lib/v4/compile.js
+++ b/lib/v4/compile.js
@@ -6,6 +6,7 @@ const assert = require('assert');
 const utils = require('../utils');
 const has = require('utility').has;
 const codegen = require('@protobufjs/codegen');
+const classMapCacheOn = Symbol('classMapCacheOn');
 
 let cache = new Map();
 const typeMap = {
@@ -120,8 +121,22 @@ function parseGenericTypeVar(generic, info) {
   return newGeneric;
 }
 
+/**
+ * 根据special key来区分Map层级逻辑
+ * @param {*} classMap classMap
+ */
+function getCompileCache(classMap) {
+  if (cache.get(classMapCacheOn)) {
+    if (!cache.has(classMap)) {
+      cache.set(classMap, new Map());
+    }
+    return cache.get(classMap);
+  }
+  return cache;
+}
+
 function compile(uniqueId, info, classMap, version, options) {
-  const compileCache = classMap && classMap.$compileCache || cache;
+  const compileCache = getCompileCache(classMap);
   let encodeFn = compileCache.get(uniqueId);
   if (encodeFn) return encodeFn;
 
@@ -257,3 +272,5 @@ module.exports.setCache = function(newCache) {
 module.exports.getCache = function() {
   return cache;
 };
+
+module.exports.classMapCacheOn = classMapCacheOn;

--- a/lib/v4/compile.js
+++ b/lib/v4/compile.js
@@ -121,7 +121,7 @@ function parseGenericTypeVar(generic, info) {
 }
 
 function compile(uniqueId, info, classMap, version, options) {
-  const compileCache = classMap && classMap.compileCache || cache;
+  const compileCache = classMap && classMap.$compileCache || cache;
   let encodeFn = compileCache.get(uniqueId);
   if (encodeFn) return encodeFn;
 

--- a/lib/v4/compile.js
+++ b/lib/v4/compile.js
@@ -122,17 +122,18 @@ function parseGenericTypeVar(generic, info) {
 }
 
 /**
- * 根据special key来区分Map层级逻辑
- * @param {*} classMap classMap
+ * special key to determine the map structure logic
+ * @param {Map<string, object>} classMap class data required for compile
  */
 function getCompileCache(classMap) {
-  if (cache.get(classMapCacheOn)) {
-    if (!cache.has(classMap)) {
-      cache.set(classMap, new Map());
-    }
-    return cache.get(classMap);
+  if (!cache.get(classMapCacheOn)) {
+    return cache;
   }
-  return cache;
+  // If there is a special key, the cache uses the classmap dimension to establish a secondary cache structure. Different classmaps use different caches
+  if (!cache.has(classMap)) {
+    cache.set(classMap, new Map());
+  }
+  return cache.get(classMap);
 }
 
 function compile(uniqueId, info, classMap, version, options) {

--- a/lib/v4/compile.js
+++ b/lib/v4/compile.js
@@ -7,7 +7,7 @@ const utils = require('../utils');
 const has = require('utility').has;
 const codegen = require('@protobufjs/codegen');
 
-let cacheWeakMap = new WeakMap();
+let cache = new Map();
 const typeMap = {
   bool: require('../primitive_type/boolean'),
   boolean: require('../primitive_type/boolean'),
@@ -121,10 +121,7 @@ function parseGenericTypeVar(generic, info) {
 }
 
 function compile(uniqueId, info, classMap, version, options) {
-  if (!cacheWeakMap.has(classMap)) {
-    cacheWeakMap.set(classMap, new Map());
-  }
-  const compileCache = cacheWeakMap.get(classMap);
+  const compileCache = classMap && classMap.$compileCache || cache;
   let encodeFn = compileCache.get(uniqueId);
   if (encodeFn) return encodeFn;
 
@@ -255,8 +252,8 @@ module.exports = function (compile, classMap, version, utils) {
 
 // for special use, don't do this unless you know what u'r doing
 module.exports.setCache = function(newCache) {
-  cacheWeakMap = newCache;
+  cache = newCache;
 };
 module.exports.getCache = function() {
-  return cacheWeakMap;
+  return cache;
 };

--- a/lib/v4/compile.js
+++ b/lib/v4/compile.js
@@ -7,7 +7,7 @@ const utils = require('../utils');
 const has = require('utility').has;
 const codegen = require('@protobufjs/codegen');
 
-let cache = new Map();
+let cacheWeakMap = new WeakMap();
 const typeMap = {
   bool: require('../primitive_type/boolean'),
   boolean: require('../primitive_type/boolean'),
@@ -121,7 +121,10 @@ function parseGenericTypeVar(generic, info) {
 }
 
 function compile(uniqueId, info, classMap, version, options) {
-  const compileCache = classMap && classMap.$compileCache || cache;
+  if (!cacheWeakMap.has(classMap)) {
+    cacheWeakMap.set(classMap, new Map());
+  }
+  const compileCache = cacheWeakMap.get(classMap);
   let encodeFn = compileCache.get(uniqueId);
   if (encodeFn) return encodeFn;
 
@@ -252,8 +255,8 @@ module.exports = function (compile, classMap, version, utils) {
 
 // for special use, don't do this unless you know what u'r doing
 module.exports.setCache = function(newCache) {
-  cache = newCache;
+  cacheWeakMap = newCache;
 };
 module.exports.getCache = function() {
-  return cache;
+  return cacheWeakMap;
 };

--- a/test/compile.test.js
+++ b/test/compile.test.js
@@ -15,42 +15,25 @@ describe('test/compile.test.js', () => {
   });
 
   it('should compile setCache work', () => {
+    const classMap = {};
     const cacheObj = { get: () => { throw new Error('mock error'); }, set: () => {} };
-    compile.setCache(cacheObj);
+    const weakCache = new WeakMap();
+
+    weakCache.set(classMap, cacheObj);
+    compile.setCache(weakCache);
 
     try {
       encode({
         $class: 'java.util.Map',
         $: { foo: 'bar' },
         isMap: true,
-      }, '2.0', {}, {}, {});
+      }, '2.0', classMap, {}, {});
       assert(false, 'never here');
     } catch (err) {
       assert(err.message === 'mock error');
     }
 
     // recover
-    compile.setCache(new Map());
-  });
-
-  it('should compile compileCache work', () => {
-
-    try {
-      encode({
-        $class: 'java.util.Map',
-        $: { foo: 'bar' },
-        isMap: true,
-      }, '2.0', {
-        $compileCache: {
-          get() {
-            throw new Error('mock error');
-          },
-          set() {},
-        },
-      }, {}, {});
-      assert(false, 'never here');
-    } catch (err) {
-      assert(err.message === 'mock error');
-    }
+    compile.setCache(new WeakMap());
   });
 });

--- a/test/compile.test.js
+++ b/test/compile.test.js
@@ -15,25 +15,42 @@ describe('test/compile.test.js', () => {
   });
 
   it('should compile setCache work', () => {
-    const classMap = {};
     const cacheObj = { get: () => { throw new Error('mock error'); }, set: () => {} };
-    const weakCache = new WeakMap();
-
-    weakCache.set(classMap, cacheObj);
-    compile.setCache(weakCache);
+    compile.setCache(cacheObj);
 
     try {
       encode({
         $class: 'java.util.Map',
         $: { foo: 'bar' },
         isMap: true,
-      }, '2.0', classMap, {}, {});
+      }, '2.0', {}, {}, {});
       assert(false, 'never here');
     } catch (err) {
       assert(err.message === 'mock error');
     }
 
     // recover
-    compile.setCache(new WeakMap());
+    compile.setCache(new Map());
+  });
+
+  it('should compile compileCache work', () => {
+
+    try {
+      encode({
+        $class: 'java.util.Map',
+        $: { foo: 'bar' },
+        isMap: true,
+      }, '2.0', {
+        $compileCache: {
+          get() {
+            throw new Error('mock error');
+          },
+          set() {},
+        },
+      }, {}, {});
+      assert(false, 'never here');
+    } catch (err) {
+      assert(err.message === 'mock error');
+    }
   });
 });

--- a/test/compile.test.js
+++ b/test/compile.test.js
@@ -34,13 +34,14 @@ describe('test/compile.test.js', () => {
   });
 
   it('should compile compileCache work', () => {
+
     try {
       encode({
         $class: 'java.util.Map',
         $: { foo: 'bar' },
         isMap: true,
       }, '2.0', {
-        compileCache: {
+        $compileCache: {
           get() {
             throw new Error('mock error');
           },

--- a/test/compile.test.js
+++ b/test/compile.test.js
@@ -32,4 +32,24 @@ describe('test/compile.test.js', () => {
     // recover
     compile.setCache(new Map());
   });
+
+  it('should compile compileCache work', () => {
+    try {
+      encode({
+        $class: 'java.util.Map',
+        $: { foo: 'bar' },
+        isMap: true,
+      }, '2.0', {
+        compileCache: {
+          get() {
+            throw new Error('mock error');
+          },
+          set() {},
+        },
+      }, {}, {});
+      assert(false, 'never here');
+    } catch (err) {
+      assert(err.message === 'mock error');
+    }
+  });
 });

--- a/test/compile.test.js
+++ b/test/compile.test.js
@@ -33,24 +33,22 @@ describe('test/compile.test.js', () => {
     compile.setCache(new Map());
   });
 
-  it('should compile compileCache work', () => {
+  it('should compile setCache WeakMap work', () => {
+    const classMap = {};
+    const cacheObj = { get: () => { throw new Error('mock error'); }, set: () => {} };
+    compile.setCache(new Map([[ compile.classMapCacheOn, true ], [ classMap, cacheObj ]]));
 
     try {
       encode({
         $class: 'java.util.Map',
         $: { foo: 'bar' },
         isMap: true,
-      }, '2.0', {
-        $compileCache: {
-          get() {
-            throw new Error('mock error');
-          },
-          set() {},
-        },
-      }, {}, {});
+      }, '2.0', classMap, {}, {});
       assert(false, 'never here');
     } catch (err) {
       assert(err.message === 'mock error');
     }
+    // recover
+    compile.setCache(new Map());
   });
 });

--- a/test/hessian.test.js
+++ b/test/hessian.test.js
@@ -1688,6 +1688,121 @@ describe('test/hessian.test.js', () => {
             }, version, classMap, {}, options);
             assert.deepEqual(buf1, buf2);
           });
+
+          it('should compile class different version work', () => {
+            const compileOptions = {
+              ...options,
+              debug: false, // com.sofa.TestObject生成的debug文件更新后，再次require会有缓存，是有利这里关闭debug
+            };
+            // com.sofa.TestObject 版本1
+            const classMap1 = {
+              'com.sofa.TestObject': {
+                field1: {
+                  type: 'java.lang.String',
+                },
+                field2: {
+                  type: 'com.sofa.TestObjectChild1',
+                },
+              },
+              'com.sofa.TestObjectChild1': {
+                field1: {
+                  type: 'java.lang.String',
+                },
+              },
+              $compileCache: new Map(),
+            };
+            const bufHessain1 = hessian.encode({
+              $class: 'com.sofa.TestObject',
+              $: {
+                field1: 'foo',
+                field2: {
+                  $class: 'com.sofa.TestObjectChild1',
+                  $: {
+                    field1: 'foo',
+                  },
+                },
+              },
+            }, version);
+            const buf11 = encode({
+              $class: 'com.sofa.TestObject',
+              $: {
+                field1: 'foo',
+                field2: {
+                  field1: 'foo',
+                },
+              },
+            }, version, classMap1, classMap1, compileOptions);
+            const buf12 = encode({
+              $class: 'com.sofa.TestObject',
+              $: {
+                field1: 'foo',
+                field2: {
+                  field1: 'foo',
+                },
+              },
+            }, version, classMap1, classMap1, compileOptions);
+
+            assert.deepEqual(bufHessain1, buf11);
+            assert.deepEqual(buf11, buf12);
+
+
+            // com.sofa.TestObject 版本2
+            const classMap2 = {
+              'com.sofa.TestObject': {
+                field1: {
+                  type: 'java.lang.String',
+                },
+                field2: {
+                  type: 'java.lang.String',
+                },
+                field3: {
+                  type: 'com.sofa.TestObjectChild2',
+                },
+              },
+              'com.sofa.TestObjectChild2': {
+                field2: {
+                  type: 'java.lang.String',
+                },
+              },
+              $compileCache: new Map(),
+            };
+            const bufHessain2 = hessian.encode({
+              $class: 'com.sofa.TestObject',
+              $: {
+                field1: 'foo',
+                field2: 'bar',
+                field3: {
+                  $class: 'com.sofa.TestObjectChild2',
+                  $: {
+                    field2: 'foo',
+                  },
+                },
+              },
+            }, version);
+            const buf21 = encode({
+              $class: 'com.sofa.TestObject',
+              $: {
+                field1: 'foo',
+                field2: 'bar',
+                field3: {
+                  field2: 'foo',
+                },
+              },
+            }, version, classMap2, classMap2, compileOptions);
+            const buf22 = encode({
+              $class: 'com.sofa.TestObject',
+              $: {
+                field1: 'foo',
+                field2: 'bar',
+                field3: {
+                  field2: 'foo',
+                },
+              },
+            }, version, classMap2, classMap2, compileOptions);
+
+            assert.deepEqual(bufHessain2, buf21);
+            assert.deepEqual(buf21, buf22);
+          });
         });
       });
 

--- a/test/hessian.test.js
+++ b/test/hessian.test.js
@@ -1690,9 +1690,10 @@ describe('test/hessian.test.js', () => {
           });
 
           it('should compile class different version work', () => {
+            compile.setCache(new Map([[ compile.classMapCacheOn, true ]]));
             const compileOptions = {
               ...options,
-              debug: false, // com.sofa.TestObject生成的debug文件更新后，再次require会有缓存，是有利这里关闭debug
+              debug: false, // com.sofa.TestObject生成的debug文件更新后，再次require会有缓存，所以这里关闭debug
             };
             // com.sofa.TestObject 版本1
             const classMap1 = {
@@ -1709,7 +1710,6 @@ describe('test/hessian.test.js', () => {
                   type: 'java.lang.String',
                 },
               },
-              $compileCache: new Map(),
             };
             const bufHessain1 = hessian.encode({
               $class: 'com.sofa.TestObject',
@@ -1764,7 +1764,6 @@ describe('test/hessian.test.js', () => {
                   type: 'java.lang.String',
                 },
               },
-              $compileCache: new Map(),
             };
             const bufHessain2 = hessian.encode({
               $class: 'com.sofa.TestObject',
@@ -1802,6 +1801,7 @@ describe('test/hessian.test.js', () => {
 
             assert.deepEqual(bufHessain2, buf21);
             assert.deepEqual(buf21, buf22);
+            compile.setCache(new Map());
           });
         });
       });

--- a/test/hessian.test.js
+++ b/test/hessian.test.js
@@ -34,7 +34,7 @@ describe('test/hessian.test.js', () => {
       ];
 
       afterEach(() => {
-        compile.getCache().clear();
+        compile.setCache(new WeakMap());
         mm.restore();
       });
 
@@ -47,16 +47,17 @@ describe('test/hessian.test.js', () => {
           });
 
           it('should encode java.util.Map without generic', () => {
+            const classMap = {};
             const obj = {
               $class: 'java.util.Map',
               $: { foo: 'bar' },
               isMap: true,
             };
             const buf1 = hessian.encode({ $class: 'java.util.Map', $: { foo: 'bar' } }, version);
-            const buf2 = encode(obj, version, {}, {}, options);
+            const buf2 = encode(obj, version, classMap, {}, options);
             assert.deepEqual(buf1, buf2);
 
-            const buf3 = encode(obj, version, {}, {}, options);
+            const buf3 = encode(obj, version, classMap, {}, options);
             assert.deepEqual(buf1, buf3);
 
             const map = new Map();
@@ -66,14 +67,15 @@ describe('test/hessian.test.js', () => {
               $class: 'java.util.Map',
               $: { foo: { $class: 'java.lang.String', $: 'bar' } },
             }, version);
-            const buf5 = encode(obj, version, {}, {}, options);
+            const buf5 = encode(obj, version, classMap, {}, options);
             assert.deepEqual(buf4, buf5);
 
-            const buf6 = encode(obj, version, {}, {}, options);
+            const buf6 = encode(obj, version, classMap, {}, options);
             assert.deepEqual(buf4, buf6);
           });
 
           it('should encode java.util.Map with generic', () => {
+            const classMap = {};
             const map = new Map();
             map.set(1, 'xxx');
             const obj = {
@@ -93,22 +95,23 @@ describe('test/hessian.test.js', () => {
             converted.$.set({ $class: 'java.lang.Integer', $: 1 }, { $class: 'java.lang.String', $: 'xxx' });
 
             const buf1 = hessian.encode(converted, version);
-            const buf2 = encode(obj, version, {}, {}, options);
+            const buf2 = encode(obj, version, classMap, {}, options);
             assert.deepEqual(buf1, buf2);
 
-            const buf3 = encode(obj, version, {}, {}, options);
+            const buf3 = encode(obj, version, classMap, {}, options);
             assert.deepEqual(buf1, buf3);
 
             obj.$ = { 1: 'xxx' };
             const buf4 = hessian.encode(converted, version);
-            const buf5 = encode(obj, version, {}, {}, options);
+            const buf5 = encode(obj, version, classMap, {}, options);
             assert.deepEqual(buf4, buf5);
 
-            const buf6 = encode(obj, version, {}, {}, options);
+            const buf6 = encode(obj, version, classMap, {}, options);
             assert.deepEqual(buf4, buf6);
           });
 
           it('should encode java.util.List with generic', () => {
+            const classMap = {};
             const obj = {
               $class: 'java.util.List',
               $: [ 'foo', 'bar' ],
@@ -122,27 +125,29 @@ describe('test/hessian.test.js', () => {
                 { $class: 'java.lang.String', $: 'bar' },
               ],
             }, version, {}, {}, options);
-            const buf2 = encode(obj, version, {}, {}, options);
+            const buf2 = encode(obj, version, classMap, {}, options);
             assert.deepEqual(buf1, buf2);
 
-            const buf3 = encode(obj, version, {}, {}, options);
+            const buf3 = encode(obj, version, classMap, {}, options);
             assert.deepEqual(buf1, buf3);
           });
 
           it('should encode java.util.List without generic', () => {
+            const classMap = {};
             const obj = {
               $class: 'java.util.List',
               $: [ 'foo', 'bar' ],
             };
             const buf1 = hessian.encode({ $class: 'java.util.List', $: [ 'foo', 'bar' ] }, version);
-            const buf2 = encode(obj, version, {}, {}, options);
+            const buf2 = encode(obj, version, classMap, {}, options);
             assert.deepEqual(buf1, buf2);
 
-            const buf3 = encode(obj, version, {}, {}, options);
+            const buf3 = encode(obj, version, classMap, {}, options);
             assert.deepEqual(buf1, buf3);
           });
 
           it('should encode java.util.ArrayList with generic', () => {
+            const classMap = {};
             const obj = {
               $class: 'java.util.ArrayList',
               $: [ 'foo', 'bar' ],
@@ -155,27 +160,29 @@ describe('test/hessian.test.js', () => {
               $: [ 'foo', 'bar' ],
               generic: [ 'java.lang.String' ],
             }, version);
-            const buf2 = encode(obj, version, {}, {}, options);
+            const buf2 = encode(obj, version, classMap, {}, options);
             assert.deepEqual(buf1, buf2);
 
-            const buf3 = encode(obj, version, {}, {}, options);
+            const buf3 = encode(obj, version, classMap, {}, options);
             assert.deepEqual(buf1, buf3);
           });
 
           it('should encode java.util.ArrayList without generic', () => {
+            const classMap = {};
             const obj = {
               $class: 'java.util.ArrayList',
               $: [ 'foo', 'bar' ],
             };
             const buf1 = hessian.encode({ $class: 'java.util.ArrayList', $: [ 'foo', 'bar' ] }, version);
-            const buf2 = encode(obj, version, {}, {}, options);
+            const buf2 = encode(obj, version, classMap, {}, options);
             assert.deepEqual(buf1, buf2);
 
-            const buf3 = encode(obj, version, {}, {}, options);
+            const buf3 = encode(obj, version, classMap, {}, options);
             assert.deepEqual(buf1, buf3);
           });
 
           it('should encode java.util.Set with generic', () => {
+            const classMap = {};
             const obj = {
               $class: 'java.util.Set',
               $: [ 'foo', 'bar' ],
@@ -189,27 +196,29 @@ describe('test/hessian.test.js', () => {
                 { $class: 'java.lang.String', $: 'bar' },
               ],
             }, version);
-            const buf2 = encode(obj, version, {}, {}, options);
+            const buf2 = encode(obj, version, classMap, {}, options);
             assert.deepEqual(buf1, buf2);
 
-            const buf3 = encode(obj, version, {}, {}, options);
+            const buf3 = encode(obj, version, classMap, {}, options);
             assert.deepEqual(buf1, buf3);
           });
 
           it('should encode java.util.Set without generic', () => {
+            const classMap = {};
             const obj = {
               $class: 'java.util.Set',
               $: [ 'foo', 'bar' ],
             };
             const buf1 = hessian.encode({ $class: 'java.util.Set', $: [ 'foo', 'bar' ] }, version);
-            const buf2 = encode(obj, version, {}, {}, options);
+            const buf2 = encode(obj, version, classMap, {}, options);
             assert.deepEqual(buf1, buf2);
 
-            const buf3 = encode(obj, version, {}, {}, options);
+            const buf3 = encode(obj, version, classMap, {}, options);
             assert.deepEqual(buf1, buf3);
           });
 
           it('should encode enum with old name', () => {
+            const classMap = {};
             const obj = {
               $class: 'com.test.model.datum.DatumStaus',
               $: {
@@ -227,14 +236,15 @@ describe('test/hessian.test.js', () => {
               $class: 'com.test.model.datum.DatumStaus',
               $: { name: 'PRERELEASING' },
             }, version);
-            const buf2 = encode(obj, version, {}, {}, options);
+            const buf2 = encode(obj, version, classMap, {}, options);
             assert.deepEqual(buf1, buf2);
 
-            const buf3 = encode(obj, version, {}, {}, options);
+            const buf3 = encode(obj, version, classMap, {}, options);
             assert.deepEqual(buf1, buf3);
           });
 
           it('should encode enum new $name', () => {
+            const classMap = {};
             const obj = {
               $class: 'com.test.model.datum.DatumStaus',
               $: {
@@ -253,10 +263,10 @@ describe('test/hessian.test.js', () => {
               $class: 'com.test.model.datum.DatumStaus',
               $: { name: 'PRERELEASING' },
             }, version);
-            const buf2 = encode(obj, version, {}, {}, options);
+            const buf2 = encode(obj, version, classMap, {}, options);
             assert.deepEqual(buf1, buf2);
 
-            const buf3 = encode(obj, version, {}, {}, options);
+            const buf3 = encode(obj, version, classMap, {}, options);
             assert.deepEqual(buf1, buf3);
           });
 
@@ -698,6 +708,7 @@ describe('test/hessian.test.js', () => {
           });
 
           it('should encode java.lang.Exception', () => {
+            const classMap = {};
             const err = new Error('mock');
             const buf1 = hessian.encode(java.exception(err), version);
             const buf2 = encode({
@@ -709,10 +720,10 @@ describe('test/hessian.test.js', () => {
             const buf3 = encode({
               $class: 'java.lang.Exception',
               $: err,
-            }, version, {}, {}, options);
+            }, version, classMap, {}, options);
             assert.deepEqual(buf1, buf3);
 
-            const buf4 = encode(java.exception(err), version, {}, {}, options);
+            const buf4 = encode(java.exception(err), version, classMap, {}, options);
             assert.deepEqual(buf1, buf4);
           });
 
@@ -812,20 +823,22 @@ describe('test/hessian.test.js', () => {
 
           describe('array', () => {
             it('should encode array', () => {
+              const classMap = {};
               const obj = {
                 $class: 'int',
                 $: [ 1, 2, 3 ],
                 isArray: true,
               };
               const buf1 = hessian.encode({ $class: '[int', $: [{ $class: 'int', $: 1 }, { $class: 'int', $: 2 }, { $class: 'int', $: 3 }] }, version);
-              const buf2 = encode(obj, version, {}, {}, options);
+              const buf2 = encode(obj, version, classMap, {}, options);
               assert.deepEqual(buf1, buf2);
 
-              const buf3 = encode(obj, version, {}, {}, options);
+              const buf3 = encode(obj, version, classMap, {}, options);
               assert.deepEqual(buf1, buf3);
             });
 
             it('should encode multi-dimentional array', () => {
+              const classMap = {};
               const obj = {
                 $class: 'java.lang.String',
                 $: [
@@ -845,14 +858,15 @@ describe('test/hessian.test.js', () => {
                   ],
                 }],
               }, version);
-              const buf2 = encode(obj, version, {}, {}, options);
+              const buf2 = encode(obj, version, classMap, {}, options);
               assert.deepEqual(buf1, buf2);
 
-              const buf3 = encode(obj, version, {}, {}, options);
+              const buf3 = encode(obj, version, classMap, {}, options);
               assert.deepEqual(buf1, buf3);
             });
 
             it('should encode java.lang.Class array', () => {
+              const classMap = {};
               const obj = {
                 $class: 'java.lang.Class',
                 $: [{
@@ -873,14 +887,15 @@ describe('test/hessian.test.js', () => {
                   $: { name: '[Ljava.lang.String;' },
                 }],
               }, version);
-              const buf2 = encode(obj, version, {}, {}, options);
+              const buf2 = encode(obj, version, classMap, {}, options);
               assert.deepEqual(buf1, buf2);
 
-              const buf3 = encode(obj, version, {}, {}, options);
+              const buf3 = encode(obj, version, classMap, {}, options);
               assert.deepEqual(buf1, buf3);
             });
 
             it('should encode java.util.Locale array', () => {
+              const classMap = {};
               const obj = {
                 $class: 'java.util.Locale',
                 $: [
@@ -896,14 +911,15 @@ describe('test/hessian.test.js', () => {
                   { $class: 'com.caucho.hessian.io.LocaleHandle', $: { value: 'en_US' } },
                 ],
               }, version);
-              const buf2 = encode(obj, version, {}, {}, options);
+              const buf2 = encode(obj, version, classMap, {}, options);
               assert.deepEqual(buf1, buf2);
 
-              const buf3 = encode(obj, version, {}, {}, options);
+              const buf3 = encode(obj, version, classMap, {}, options);
               assert.deepEqual(buf1, buf3);
             });
 
             it('should encode java.math.BigDecimal array', () => {
+              const classMap = {};
               const obj = {
                 $class: 'java.math.BigDecimal',
                 $: [
@@ -913,14 +929,15 @@ describe('test/hessian.test.js', () => {
                 isArray: true,
               };
               const buf1 = hessian.encode(java.array.BigDecimal(obj.$), version);
-              const buf2 = encode(obj, version, {}, {}, options);
+              const buf2 = encode(obj, version, classMap, {}, options);
               assert.deepEqual(buf1, buf2);
 
-              const buf3 = encode(obj, version, {}, {}, options);
+              const buf3 = encode(obj, version, classMap, {}, options);
               assert.deepEqual(buf1, buf3);
             });
 
             it('should encode java.util.Currency array', () => {
+              const classMap = {};
               const obj = {
                 $class: 'java.util.Currency',
                 $: [
@@ -936,38 +953,40 @@ describe('test/hessian.test.js', () => {
                   { $class: 'java.util.Currency', $: { currencyCode: 'USD' } },
                 ],
               }, version);
-              const buf2 = encode(obj, version, {}, {}, options);
+              const buf2 = encode(obj, version, classMap, {}, options);
               assert.deepEqual(buf1, buf2);
 
-              const buf3 = encode(obj, version, {}, {}, options);
+              const buf3 = encode(obj, version, classMap, {}, options);
               assert.deepEqual(buf1, buf3);
             });
 
             it('should encode byte array', () => {
+              const classMap = {};
               const obj = {
                 $class: 'byte',
                 $: Buffer.from('hello world'),
                 isArray: true,
               };
               const buf1 = hessian.encode(Buffer.from('hello world'), version);
-              const buf2 = encode(obj, version, {}, {}, options);
+              const buf2 = encode(obj, version, classMap, {}, options);
               assert.deepEqual(buf1, buf2);
 
-              const buf3 = encode(obj, version, {}, {}, options);
+              const buf3 = encode(obj, version, classMap, {}, options);
               assert.deepEqual(buf1, buf3);
             });
 
             it('should encode java.lang.Byte array', () => {
+              const classMap = {};
               const obj = {
                 $class: 'java.lang.Byte',
                 $: Buffer.from('hello world'),
                 isArray: true,
               };
               const buf1 = hessian.encode(Buffer.from('hello world'), version);
-              const buf2 = encode(obj, version, {}, {}, options);
+              const buf2 = encode(obj, version, classMap, {}, options);
               assert.deepEqual(buf1, buf2);
 
-              const buf3 = encode(obj, version, {}, {}, options);
+              const buf3 = encode(obj, version, classMap, {}, options);
               assert.deepEqual(buf1, buf3);
             });
           });
@@ -1015,6 +1034,7 @@ describe('test/hessian.test.js', () => {
           });
 
           it('should support java.util.concurrent.atomic.AtomicLong', () => {
+            const classMap = {};
             const obj = {
               $class: 'java.util.concurrent.atomic.AtomicLong',
               $: '100',
@@ -1028,14 +1048,15 @@ describe('test/hessian.test.js', () => {
                 },
               },
             }, version);
-            const buf2 = encode(obj, version, {}, {}, options);
+            const buf2 = encode(obj, version, classMap, {}, options);
             assert.deepEqual(buf1, buf2);
 
-            const buf3 = encode(obj, version, {}, {}, options);
+            const buf3 = encode(obj, version, classMap, {}, options);
             assert.deepEqual(buf1, buf3);
           });
 
           it('should support java.util.concurrent.atomic.AtomicLong 2', () => {
+            const classMap = {};
             const obj = {
               $class: 'java.util.concurrent.atomic.AtomicLong',
               $: {
@@ -1051,14 +1072,15 @@ describe('test/hessian.test.js', () => {
                 },
               },
             }, version);
-            const buf2 = encode(obj, version, {}, {}, options);
+            const buf2 = encode(obj, version, classMap, {}, options);
             assert.deepEqual(buf1, buf2);
 
-            const buf3 = encode(obj, version, {}, {}, options);
+            const buf3 = encode(obj, version, classMap, {}, options);
             assert.deepEqual(buf1, buf3);
           });
 
           it('should support java.util.concurrent.atomic.AtomicLong 3', () => {
+            const classMap = {};
             const obj = {
               $class: 'java.util.concurrent.atomic.AtomicLong',
               $: {
@@ -1077,10 +1099,10 @@ describe('test/hessian.test.js', () => {
                 },
               },
             }, version);
-            const buf2 = encode(obj, version, {}, {}, options);
+            const buf2 = encode(obj, version, classMap, {}, options);
             assert.deepEqual(buf1, buf2);
 
-            const buf3 = encode(obj, version, {}, {}, options);
+            const buf3 = encode(obj, version, classMap, {}, options);
             assert.deepEqual(buf1, buf3);
           });
 
@@ -1709,7 +1731,6 @@ describe('test/hessian.test.js', () => {
                   type: 'java.lang.String',
                 },
               },
-              $compileCache: new Map(),
             };
             const bufHessain1 = hessian.encode({
               $class: 'com.sofa.TestObject',
@@ -1764,7 +1785,6 @@ describe('test/hessian.test.js', () => {
                   type: 'java.lang.String',
                 },
               },
-              $compileCache: new Map(),
             };
             const bufHessain2 = hessian.encode({
               $class: 'com.sofa.TestObject',

--- a/test/hessian.test.js
+++ b/test/hessian.test.js
@@ -34,7 +34,7 @@ describe('test/hessian.test.js', () => {
       ];
 
       afterEach(() => {
-        compile.setCache(new WeakMap());
+        compile.getCache().clear();
         mm.restore();
       });
 
@@ -47,17 +47,16 @@ describe('test/hessian.test.js', () => {
           });
 
           it('should encode java.util.Map without generic', () => {
-            const classMap = {};
             const obj = {
               $class: 'java.util.Map',
               $: { foo: 'bar' },
               isMap: true,
             };
             const buf1 = hessian.encode({ $class: 'java.util.Map', $: { foo: 'bar' } }, version);
-            const buf2 = encode(obj, version, classMap, {}, options);
+            const buf2 = encode(obj, version, {}, {}, options);
             assert.deepEqual(buf1, buf2);
 
-            const buf3 = encode(obj, version, classMap, {}, options);
+            const buf3 = encode(obj, version, {}, {}, options);
             assert.deepEqual(buf1, buf3);
 
             const map = new Map();
@@ -67,15 +66,14 @@ describe('test/hessian.test.js', () => {
               $class: 'java.util.Map',
               $: { foo: { $class: 'java.lang.String', $: 'bar' } },
             }, version);
-            const buf5 = encode(obj, version, classMap, {}, options);
+            const buf5 = encode(obj, version, {}, {}, options);
             assert.deepEqual(buf4, buf5);
 
-            const buf6 = encode(obj, version, classMap, {}, options);
+            const buf6 = encode(obj, version, {}, {}, options);
             assert.deepEqual(buf4, buf6);
           });
 
           it('should encode java.util.Map with generic', () => {
-            const classMap = {};
             const map = new Map();
             map.set(1, 'xxx');
             const obj = {
@@ -95,23 +93,22 @@ describe('test/hessian.test.js', () => {
             converted.$.set({ $class: 'java.lang.Integer', $: 1 }, { $class: 'java.lang.String', $: 'xxx' });
 
             const buf1 = hessian.encode(converted, version);
-            const buf2 = encode(obj, version, classMap, {}, options);
+            const buf2 = encode(obj, version, {}, {}, options);
             assert.deepEqual(buf1, buf2);
 
-            const buf3 = encode(obj, version, classMap, {}, options);
+            const buf3 = encode(obj, version, {}, {}, options);
             assert.deepEqual(buf1, buf3);
 
             obj.$ = { 1: 'xxx' };
             const buf4 = hessian.encode(converted, version);
-            const buf5 = encode(obj, version, classMap, {}, options);
+            const buf5 = encode(obj, version, {}, {}, options);
             assert.deepEqual(buf4, buf5);
 
-            const buf6 = encode(obj, version, classMap, {}, options);
+            const buf6 = encode(obj, version, {}, {}, options);
             assert.deepEqual(buf4, buf6);
           });
 
           it('should encode java.util.List with generic', () => {
-            const classMap = {};
             const obj = {
               $class: 'java.util.List',
               $: [ 'foo', 'bar' ],
@@ -125,29 +122,27 @@ describe('test/hessian.test.js', () => {
                 { $class: 'java.lang.String', $: 'bar' },
               ],
             }, version, {}, {}, options);
-            const buf2 = encode(obj, version, classMap, {}, options);
+            const buf2 = encode(obj, version, {}, {}, options);
             assert.deepEqual(buf1, buf2);
 
-            const buf3 = encode(obj, version, classMap, {}, options);
+            const buf3 = encode(obj, version, {}, {}, options);
             assert.deepEqual(buf1, buf3);
           });
 
           it('should encode java.util.List without generic', () => {
-            const classMap = {};
             const obj = {
               $class: 'java.util.List',
               $: [ 'foo', 'bar' ],
             };
             const buf1 = hessian.encode({ $class: 'java.util.List', $: [ 'foo', 'bar' ] }, version);
-            const buf2 = encode(obj, version, classMap, {}, options);
+            const buf2 = encode(obj, version, {}, {}, options);
             assert.deepEqual(buf1, buf2);
 
-            const buf3 = encode(obj, version, classMap, {}, options);
+            const buf3 = encode(obj, version, {}, {}, options);
             assert.deepEqual(buf1, buf3);
           });
 
           it('should encode java.util.ArrayList with generic', () => {
-            const classMap = {};
             const obj = {
               $class: 'java.util.ArrayList',
               $: [ 'foo', 'bar' ],
@@ -160,29 +155,27 @@ describe('test/hessian.test.js', () => {
               $: [ 'foo', 'bar' ],
               generic: [ 'java.lang.String' ],
             }, version);
-            const buf2 = encode(obj, version, classMap, {}, options);
+            const buf2 = encode(obj, version, {}, {}, options);
             assert.deepEqual(buf1, buf2);
 
-            const buf3 = encode(obj, version, classMap, {}, options);
+            const buf3 = encode(obj, version, {}, {}, options);
             assert.deepEqual(buf1, buf3);
           });
 
           it('should encode java.util.ArrayList without generic', () => {
-            const classMap = {};
             const obj = {
               $class: 'java.util.ArrayList',
               $: [ 'foo', 'bar' ],
             };
             const buf1 = hessian.encode({ $class: 'java.util.ArrayList', $: [ 'foo', 'bar' ] }, version);
-            const buf2 = encode(obj, version, classMap, {}, options);
+            const buf2 = encode(obj, version, {}, {}, options);
             assert.deepEqual(buf1, buf2);
 
-            const buf3 = encode(obj, version, classMap, {}, options);
+            const buf3 = encode(obj, version, {}, {}, options);
             assert.deepEqual(buf1, buf3);
           });
 
           it('should encode java.util.Set with generic', () => {
-            const classMap = {};
             const obj = {
               $class: 'java.util.Set',
               $: [ 'foo', 'bar' ],
@@ -196,29 +189,27 @@ describe('test/hessian.test.js', () => {
                 { $class: 'java.lang.String', $: 'bar' },
               ],
             }, version);
-            const buf2 = encode(obj, version, classMap, {}, options);
+            const buf2 = encode(obj, version, {}, {}, options);
             assert.deepEqual(buf1, buf2);
 
-            const buf3 = encode(obj, version, classMap, {}, options);
+            const buf3 = encode(obj, version, {}, {}, options);
             assert.deepEqual(buf1, buf3);
           });
 
           it('should encode java.util.Set without generic', () => {
-            const classMap = {};
             const obj = {
               $class: 'java.util.Set',
               $: [ 'foo', 'bar' ],
             };
             const buf1 = hessian.encode({ $class: 'java.util.Set', $: [ 'foo', 'bar' ] }, version);
-            const buf2 = encode(obj, version, classMap, {}, options);
+            const buf2 = encode(obj, version, {}, {}, options);
             assert.deepEqual(buf1, buf2);
 
-            const buf3 = encode(obj, version, classMap, {}, options);
+            const buf3 = encode(obj, version, {}, {}, options);
             assert.deepEqual(buf1, buf3);
           });
 
           it('should encode enum with old name', () => {
-            const classMap = {};
             const obj = {
               $class: 'com.test.model.datum.DatumStaus',
               $: {
@@ -236,15 +227,14 @@ describe('test/hessian.test.js', () => {
               $class: 'com.test.model.datum.DatumStaus',
               $: { name: 'PRERELEASING' },
             }, version);
-            const buf2 = encode(obj, version, classMap, {}, options);
+            const buf2 = encode(obj, version, {}, {}, options);
             assert.deepEqual(buf1, buf2);
 
-            const buf3 = encode(obj, version, classMap, {}, options);
+            const buf3 = encode(obj, version, {}, {}, options);
             assert.deepEqual(buf1, buf3);
           });
 
           it('should encode enum new $name', () => {
-            const classMap = {};
             const obj = {
               $class: 'com.test.model.datum.DatumStaus',
               $: {
@@ -263,10 +253,10 @@ describe('test/hessian.test.js', () => {
               $class: 'com.test.model.datum.DatumStaus',
               $: { name: 'PRERELEASING' },
             }, version);
-            const buf2 = encode(obj, version, classMap, {}, options);
+            const buf2 = encode(obj, version, {}, {}, options);
             assert.deepEqual(buf1, buf2);
 
-            const buf3 = encode(obj, version, classMap, {}, options);
+            const buf3 = encode(obj, version, {}, {}, options);
             assert.deepEqual(buf1, buf3);
           });
 
@@ -708,7 +698,6 @@ describe('test/hessian.test.js', () => {
           });
 
           it('should encode java.lang.Exception', () => {
-            const classMap = {};
             const err = new Error('mock');
             const buf1 = hessian.encode(java.exception(err), version);
             const buf2 = encode({
@@ -720,10 +709,10 @@ describe('test/hessian.test.js', () => {
             const buf3 = encode({
               $class: 'java.lang.Exception',
               $: err,
-            }, version, classMap, {}, options);
+            }, version, {}, {}, options);
             assert.deepEqual(buf1, buf3);
 
-            const buf4 = encode(java.exception(err), version, classMap, {}, options);
+            const buf4 = encode(java.exception(err), version, {}, {}, options);
             assert.deepEqual(buf1, buf4);
           });
 
@@ -823,22 +812,20 @@ describe('test/hessian.test.js', () => {
 
           describe('array', () => {
             it('should encode array', () => {
-              const classMap = {};
               const obj = {
                 $class: 'int',
                 $: [ 1, 2, 3 ],
                 isArray: true,
               };
               const buf1 = hessian.encode({ $class: '[int', $: [{ $class: 'int', $: 1 }, { $class: 'int', $: 2 }, { $class: 'int', $: 3 }] }, version);
-              const buf2 = encode(obj, version, classMap, {}, options);
+              const buf2 = encode(obj, version, {}, {}, options);
               assert.deepEqual(buf1, buf2);
 
-              const buf3 = encode(obj, version, classMap, {}, options);
+              const buf3 = encode(obj, version, {}, {}, options);
               assert.deepEqual(buf1, buf3);
             });
 
             it('should encode multi-dimentional array', () => {
-              const classMap = {};
               const obj = {
                 $class: 'java.lang.String',
                 $: [
@@ -858,15 +845,14 @@ describe('test/hessian.test.js', () => {
                   ],
                 }],
               }, version);
-              const buf2 = encode(obj, version, classMap, {}, options);
+              const buf2 = encode(obj, version, {}, {}, options);
               assert.deepEqual(buf1, buf2);
 
-              const buf3 = encode(obj, version, classMap, {}, options);
+              const buf3 = encode(obj, version, {}, {}, options);
               assert.deepEqual(buf1, buf3);
             });
 
             it('should encode java.lang.Class array', () => {
-              const classMap = {};
               const obj = {
                 $class: 'java.lang.Class',
                 $: [{
@@ -887,15 +873,14 @@ describe('test/hessian.test.js', () => {
                   $: { name: '[Ljava.lang.String;' },
                 }],
               }, version);
-              const buf2 = encode(obj, version, classMap, {}, options);
+              const buf2 = encode(obj, version, {}, {}, options);
               assert.deepEqual(buf1, buf2);
 
-              const buf3 = encode(obj, version, classMap, {}, options);
+              const buf3 = encode(obj, version, {}, {}, options);
               assert.deepEqual(buf1, buf3);
             });
 
             it('should encode java.util.Locale array', () => {
-              const classMap = {};
               const obj = {
                 $class: 'java.util.Locale',
                 $: [
@@ -911,15 +896,14 @@ describe('test/hessian.test.js', () => {
                   { $class: 'com.caucho.hessian.io.LocaleHandle', $: { value: 'en_US' } },
                 ],
               }, version);
-              const buf2 = encode(obj, version, classMap, {}, options);
+              const buf2 = encode(obj, version, {}, {}, options);
               assert.deepEqual(buf1, buf2);
 
-              const buf3 = encode(obj, version, classMap, {}, options);
+              const buf3 = encode(obj, version, {}, {}, options);
               assert.deepEqual(buf1, buf3);
             });
 
             it('should encode java.math.BigDecimal array', () => {
-              const classMap = {};
               const obj = {
                 $class: 'java.math.BigDecimal',
                 $: [
@@ -929,15 +913,14 @@ describe('test/hessian.test.js', () => {
                 isArray: true,
               };
               const buf1 = hessian.encode(java.array.BigDecimal(obj.$), version);
-              const buf2 = encode(obj, version, classMap, {}, options);
+              const buf2 = encode(obj, version, {}, {}, options);
               assert.deepEqual(buf1, buf2);
 
-              const buf3 = encode(obj, version, classMap, {}, options);
+              const buf3 = encode(obj, version, {}, {}, options);
               assert.deepEqual(buf1, buf3);
             });
 
             it('should encode java.util.Currency array', () => {
-              const classMap = {};
               const obj = {
                 $class: 'java.util.Currency',
                 $: [
@@ -953,40 +936,38 @@ describe('test/hessian.test.js', () => {
                   { $class: 'java.util.Currency', $: { currencyCode: 'USD' } },
                 ],
               }, version);
-              const buf2 = encode(obj, version, classMap, {}, options);
+              const buf2 = encode(obj, version, {}, {}, options);
               assert.deepEqual(buf1, buf2);
 
-              const buf3 = encode(obj, version, classMap, {}, options);
+              const buf3 = encode(obj, version, {}, {}, options);
               assert.deepEqual(buf1, buf3);
             });
 
             it('should encode byte array', () => {
-              const classMap = {};
               const obj = {
                 $class: 'byte',
                 $: Buffer.from('hello world'),
                 isArray: true,
               };
               const buf1 = hessian.encode(Buffer.from('hello world'), version);
-              const buf2 = encode(obj, version, classMap, {}, options);
+              const buf2 = encode(obj, version, {}, {}, options);
               assert.deepEqual(buf1, buf2);
 
-              const buf3 = encode(obj, version, classMap, {}, options);
+              const buf3 = encode(obj, version, {}, {}, options);
               assert.deepEqual(buf1, buf3);
             });
 
             it('should encode java.lang.Byte array', () => {
-              const classMap = {};
               const obj = {
                 $class: 'java.lang.Byte',
                 $: Buffer.from('hello world'),
                 isArray: true,
               };
               const buf1 = hessian.encode(Buffer.from('hello world'), version);
-              const buf2 = encode(obj, version, classMap, {}, options);
+              const buf2 = encode(obj, version, {}, {}, options);
               assert.deepEqual(buf1, buf2);
 
-              const buf3 = encode(obj, version, classMap, {}, options);
+              const buf3 = encode(obj, version, {}, {}, options);
               assert.deepEqual(buf1, buf3);
             });
           });
@@ -1034,7 +1015,6 @@ describe('test/hessian.test.js', () => {
           });
 
           it('should support java.util.concurrent.atomic.AtomicLong', () => {
-            const classMap = {};
             const obj = {
               $class: 'java.util.concurrent.atomic.AtomicLong',
               $: '100',
@@ -1048,15 +1028,14 @@ describe('test/hessian.test.js', () => {
                 },
               },
             }, version);
-            const buf2 = encode(obj, version, classMap, {}, options);
+            const buf2 = encode(obj, version, {}, {}, options);
             assert.deepEqual(buf1, buf2);
 
-            const buf3 = encode(obj, version, classMap, {}, options);
+            const buf3 = encode(obj, version, {}, {}, options);
             assert.deepEqual(buf1, buf3);
           });
 
           it('should support java.util.concurrent.atomic.AtomicLong 2', () => {
-            const classMap = {};
             const obj = {
               $class: 'java.util.concurrent.atomic.AtomicLong',
               $: {
@@ -1072,15 +1051,14 @@ describe('test/hessian.test.js', () => {
                 },
               },
             }, version);
-            const buf2 = encode(obj, version, classMap, {}, options);
+            const buf2 = encode(obj, version, {}, {}, options);
             assert.deepEqual(buf1, buf2);
 
-            const buf3 = encode(obj, version, classMap, {}, options);
+            const buf3 = encode(obj, version, {}, {}, options);
             assert.deepEqual(buf1, buf3);
           });
 
           it('should support java.util.concurrent.atomic.AtomicLong 3', () => {
-            const classMap = {};
             const obj = {
               $class: 'java.util.concurrent.atomic.AtomicLong',
               $: {
@@ -1099,10 +1077,10 @@ describe('test/hessian.test.js', () => {
                 },
               },
             }, version);
-            const buf2 = encode(obj, version, classMap, {}, options);
+            const buf2 = encode(obj, version, {}, {}, options);
             assert.deepEqual(buf1, buf2);
 
-            const buf3 = encode(obj, version, classMap, {}, options);
+            const buf3 = encode(obj, version, {}, {}, options);
             assert.deepEqual(buf1, buf3);
           });
 
@@ -1731,6 +1709,7 @@ describe('test/hessian.test.js', () => {
                   type: 'java.lang.String',
                 },
               },
+              $compileCache: new Map(),
             };
             const bufHessain1 = hessian.encode({
               $class: 'com.sofa.TestObject',
@@ -1785,6 +1764,7 @@ describe('test/hessian.test.js', () => {
                   type: 'java.lang.String',
                 },
               },
+              $compileCache: new Map(),
             };
             const bufHessain2 = hessian.encode({
               $class: 'com.sofa.TestObject',


### PR DESCRIPTION
需求点:
   支持不同classMap对象，使用不同预编译缓存，实现不同classMap结构之间的缓存隔离

解决方式：
1. 通过setCache设置compile的cache，使其存在classMapCacheOn的key
2. 在获取cache时判断classMapCacheOn是否存在，如果存在则走classMap缓存的逻辑，建立二维缓存结构，一维结构的key为classMap
``` javascript
function getCompileCache(classMap) {
  if (!cache.get(classMapCacheOn)) {
    return cache;
  }
  if (!cache.has(classMap)) {
    cache.set(classMap, new Map());
  }
  return cache.get(classMap);
}
```

