### PR TITLE
fix: primitive type get type should adapt $class

### DIFF
--- a/lib/primitive_type/java.lang.class.js
+++ b/lib/primitive_type/java.lang.class.js
@@ -13,18 +13,20 @@ module.exports = (gen, classInfo, version) => {
   gen('  obj = obj.name');
   gen('}');
 
+  const type = classInfo.type || classInfo.$class;
+
   if (version === '1.0') {
     gen('encoder.byteBuffer.put(0x4d);');
-    gen('encoder.writeType(\'%s\');', classInfo.type);
+    gen('encoder.writeType(\'%s\');', type);
     gen('encoder.writeString(\'name\');');
     gen('encoder.writeString(obj);');
     gen('encoder.byteBuffer.put(0x7a);');
   } else {
-    gen('const ref = encoder._writeObjectBegin(\'%s\');', classInfo.type);
+    gen('const ref = encoder._writeObjectBegin(\'%s\');', type);
     gen('if (ref === -1) {');
     gen('encoder.writeInt(1);');
     gen('encoder.writeString(\'name\');');
-    gen('encoder._writeObjectBegin(\'%s\'); }', classInfo.type);
+    gen('encoder._writeObjectBegin(\'%s\'); }', type);
     gen('encoder.writeString(obj);');
   }
 };

--- a/lib/primitive_type/java.math.bigdecimal.js
+++ b/lib/primitive_type/java.math.bigdecimal.js
@@ -9,18 +9,20 @@ module.exports = (gen, classInfo, version) => {
   gen('  obj = obj.value || 0');
   gen('}');
 
+  const type = classInfo.type || classInfo.$class;
+
   if (version === '1.0') {
     gen('encoder.byteBuffer.put(0x4d);');
-    gen('encoder.writeType(\'%s\');', classInfo.type);
+    gen('encoder.writeType(\'%s\');', type);
     gen('encoder.writeString(\'value\');');
     gen('encoder.writeString(String(obj));');
     gen('encoder.byteBuffer.put(0x7a);');
   } else {
-    gen('const ref = encoder._writeObjectBegin(\'%s\');', classInfo.type);
+    gen('const ref = encoder._writeObjectBegin(\'%s\');', type);
     gen('if (ref === -1) {');
     gen('encoder.writeInt(1);');
     gen('encoder.writeString(\'value\');');
-    gen('encoder._writeObjectBegin(\'%s\'); }', classInfo.type);
+    gen('encoder._writeObjectBegin(\'%s\'); }', type);
     gen('encoder.writeString(String(obj));');
   }
 };

--- a/lib/primitive_type/java.util.currency.js
+++ b/lib/primitive_type/java.util.currency.js
@@ -9,18 +9,20 @@ module.exports = (gen, classInfo, version) => {
   gen('  obj = obj.currencyCode');
   gen('}');
 
+  const type = classInfo.type || classInfo.$class;
+
   if (version === '1.0') {
     gen('encoder.byteBuffer.put(0x4d);');
-    gen('encoder.writeType(\'%s\');', classInfo.type);
+    gen('encoder.writeType(\'%s\');', type);
     gen('encoder.writeString(\'currencyCode\');');
     gen('encoder.writeString(obj);');
     gen('encoder.byteBuffer.put(0x7a);');
   } else {
-    gen('const ref = encoder._writeObjectBegin(\'%s\');', classInfo.type);
+    gen('const ref = encoder._writeObjectBegin(\'%s\');', type);
     gen('if (ref === -1) {');
     gen('  encoder.writeInt(1);');
     gen('  encoder.writeString(\'currencyCode\');');
-    gen('  encoder._writeObjectBegin(\'%s\');\n}', classInfo.type);
+    gen('  encoder._writeObjectBegin(\'%s\');\n}', type);
     gen('encoder.writeString(obj);');
   }
 };

--- a/lib/primitive_type/java.util.list.js
+++ b/lib/primitive_type/java.util.list.js
@@ -7,7 +7,8 @@ module.exports = (gen, classInfo, version, options) => {
   gen('if (obj == null) { return encoder.writeNull(); }');
   gen('if (encoder._checkRef(obj)) { return; }');
 
-  gen('const hasEnd = encoder._writeListBegin(obj.length, \'%s\');', classInfo.type);
+  const type = classInfo.type || classInfo.$class;
+  gen('const hasEnd = encoder._writeListBegin(obj.length, \'%s\');', type);
 
   const generic = classInfo.generic;
   if (generic && generic.length === 1) {

--- a/lib/primitive_type/java.util.map.js
+++ b/lib/primitive_type/java.util.map.js
@@ -7,11 +7,13 @@ module.exports = (gen, classInfo, version, options) => {
   gen('if (obj == null) { return encoder.writeNull(); }');
   gen('if (encoder._checkRef(obj)) { return; }');
 
+  const type = classInfo.type || classInfo.$class;
+
   gen('encoder.byteBuffer.put(0x4d);');
-  if (classInfo.type === 'java.util.HashMap' || classInfo.type === 'java.util.Map') {
+  if (type === 'java.util.HashMap' || type === 'java.util.Map') {
     gen('encoder.writeType(\'\');');
   } else {
-    gen('encoder.writeType(\'%s\');', classInfo.type);
+    gen('encoder.writeType(\'%s\');', type);
   }
 
   const generic = classInfo.generic;

--- a/lib/primitive_type/java.util.set.js
+++ b/lib/primitive_type/java.util.set.js
@@ -7,7 +7,8 @@ module.exports = (gen, classInfo, version, options) => {
   gen('if (obj == null) { return encoder.writeNull(); }');
   gen('if (encoder._checkRef(obj)) { return; }');
 
-  gen('const hasEnd = encoder._writeListBegin(obj.size || obj.length, \'%s\');', classInfo.type);
+  const type = classInfo.type || classInfo.$class;
+  gen('const hasEnd = encoder._writeListBegin(obj.size || obj.length, \'%s\');', type);
 
   const generic = classInfo.generic;
   if (generic && generic.length === 1) {

--- a/test/edge_case.test.js
+++ b/test/edge_case.test.js
@@ -394,5 +394,88 @@ describe('test/edge_case.test.js', () => {
         setProperty: [ '233', '23333' ],
       });
     });
+
+    it('java.lang.Object pass java.util.Map type', () => {
+      const a = {
+        $class: 'java.lang.Object',
+        $: {
+          $class: 'java.util.Map',
+          $: {
+            a: 'a',
+          },
+        },
+      };
+      const buf = encode(a, version, {});
+
+      const buf1 = hessian.encode({
+        $class: 'java.util.Map',
+        $: {
+          a: 'a',
+        },
+      }, version);
+
+      assert.deepStrictEqual(buf, buf1);
+    });
+
+    it('custom class pass java.lang.Class primitive type', () => {
+      const a = {
+        $class: 'com.test.aaa',
+        $: {
+          $class: 'java.lang.Class',
+          $: {
+            name: 'a',
+          },
+        },
+      };
+      const buf = encode(a, version, {
+        'com.test.aaa': {},
+      });
+
+      const buf1 = hessian.encode({
+        $class: 'java.lang.Class',
+        $: {
+          name: 'a',
+        },
+      }, version);
+
+      assert.deepStrictEqual(buf, buf1);
+    });
+
+    it('java.lang.Object pass java.util.List type', () => {
+      const a = {
+        $class: 'java.lang.Object',
+        $: {
+          $class: 'java.util.List',
+          $: [ '1' ],
+        },
+      };
+      const buf = encode(a, version, {});
+
+      const buf1 = hessian.encode({
+        $class: 'java.util.List',
+        $: [ '1' ],
+      }, version);
+
+      assert.deepStrictEqual(buf, buf1);
+    });
+
+    it('java.lang.Object pass java.util.Set type', () => {
+      const a = {
+        $class: 'java.lang.Object',
+        $: {
+          $class: 'java.util.Set',
+          $: [ '1' ],
+        },
+      };
+      const buf = encode(a, version, {});
+
+      const buf1 = hessian.encode({
+        $class: 'java.util.Set',
+        $: [ '1' ],
+      }, version);
+
+      assert.deepStrictEqual(buf, buf1);
+    });
+
   });
 });


### PR DESCRIPTION
java.lang.Object compile 支持传递具体的 $class 再进行递归 compile，这时递归传入的 info 可能是没有 type 的，就会造成某些 privitime 递归处理里面序列化写入了 undefined

![image](https://user-images.githubusercontent.com/2160731/118917783-327f3e00-b964-11eb-8450-7b700ac7be5c.png)

同理，这里也有类似的问题  https://github.com/sofastack/sofa-hessian-node/blob/master/lib/v3/compile.js#L216-L219
