### PR TITLE
fix: wrap enum name with [""]

### DIFF
--- a/lib/v3/compile.js
+++ b/lib/v3/compile.js
@@ -195,7 +195,7 @@ function compile(uniqueId, info, classMap, version, options) {
     gen('if (clazz) {');
     gen('  const item = clazz.getBy(\'$name\', name);');
     gen('  if (!item)');
-    gen('    throw new Error(`enum: ${type} have no name: ${name}`);');
+    gen('    throw new Error(`enum: ${type} have no name: ["${name}"]`);');
     gen('}');
 
     if (version === '1.0') {

--- a/test/edge_case.test.js
+++ b/test/edge_case.test.js
@@ -206,7 +206,7 @@ describe('test/edge_case.test.js', () => {
         error = e;
       } finally {
         assert(error);
-        assert(error.message === 'enum: com.test.model.datum.DatumStaus have no name: PRERELEASING_INVALIDATE');
+        assert(error.message === 'enum: com.test.model.datum.DatumStaus have no name: ["PRERELEASING_INVALIDATE"]');
       }
     });
 


### PR DESCRIPTION
Wrap the strings of the enum name with [""] to
improve the error experience when encountering
an empty string.