### PR TITLE
fix: load generated debug encoders with createRequire

### DIFF
--- a/lib/v3/compile.js
+++ b/lib/v3/compile.js
@@ -3,10 +3,12 @@
 const fs = require('fs');
 const path = require('path');
 const assert = require('assert');
+const Module = require('module');
 const utils = require('../utils');
 const has = require('utility').has;
 const codegen = require('@protobufjs/codegen');
 const classMapCacheOn = Symbol('classMapCacheOn');
+const createRequire = Module.createRequire || Module.createRequireFromPath || (() => module.require.bind(module));
 
 let cache = new Map();
 const typeMap = {
@@ -266,7 +268,7 @@ module.exports = function (compile, classMap, version, utils) {
 `;
     const jsFile = path.join(options.debugDir, `${uniqueId}.js`);
     fs.writeFileSync(jsFile, func);
-    encodeFn = require(jsFile)(compile, classMap, version, utils);
+    encodeFn = createRequire(jsFile)(jsFile)(compile, classMap, version, utils);
   }
   compileCache.set(uniqueId, encodeFn);
   return encodeFn;

--- a/lib/v4/compile.js
+++ b/lib/v4/compile.js
@@ -3,10 +3,12 @@
 const fs = require('fs');
 const path = require('path');
 const assert = require('assert');
+const Module = require('module');
 const utils = require('../utils');
 const has = require('utility').has;
 const codegen = require('@protobufjs/codegen');
 const classMapCacheOn = Symbol('classMapCacheOn');
+const createRequire = Module.createRequire || Module.createRequireFromPath || (() => module.require.bind(module));
 
 let cache = new Map();
 const typeMap = {
@@ -261,7 +263,7 @@ module.exports = function (compile, classMap, version, utils) {
 `;
     const jsFile = path.join(options.debugDir, `${uniqueId}.js`);
     fs.writeFileSync(jsFile, func);
-    encodeFn = require(jsFile)(compile, classMap, version, utils);
+    encodeFn = createRequire(jsFile)(jsFile)(compile, classMap, version, utils);
   }
   compileCache.set(uniqueId, encodeFn);
   return encodeFn;

--- a/test/hessian.test.js
+++ b/test/hessian.test.js
@@ -1848,6 +1848,9 @@ describe('test/hessian.test.js', () => {
             'com.alipay.test.Father#2.0.js',
             'java.lang.String#2.0.js',
           ]);
+          for (const file of files) {
+            assert(require.cache[path.join(dir, file)], `${file} should be loaded as a debuggable module`);
+          }
         });
       });
     });


### PR DESCRIPTION
## Summary

- keep writing generated encoder source files in debug mode
- load the actual generated files through `module.createRequire()` instead of a bundler-visible dynamic `require(path)`
- preserve file breakpoints, stack locations, `require.cache`, and require-hook behavior for generated debug encoders
- apply the same behavior to both Hessian v3 and v4

## Root cause

`require(jsFile)` uses a runtime-computed path. When `sofa-hessian-node` is pulled into an application bundle through the TR dependency graph, the bundler must analyze this module even if the Hessian runtime path is not exercised at startup, and cannot statically resolve that path.

Using Node module `createRequire` keeps the load explicitly at runtime. The generated file remains a real CommonJS module on disk, so debuggers can enter it instead of stopping in code created by eval or `Function`.

## Compatibility

- this is a backward-compatible patch on top of `2.2.1` and is suitable for a `2.2.2` release
- public exports, function signatures, dependencies, declared Node.js requirements, Hessian wire format, and encoded output remain unchanged
- Node versions with `createRequire` use it directly; the existing Node 10 line is retained through `createRequireFromPath` and `module.require` fallbacks
- debug mode retains its previous observable behavior: generated files are executed as modules and appear in `require.cache`
- `2.2.1` and the patched version can be deployed together because no protocol or serialized-data format changes are introduced
- `package.json` intentionally remains at `2.2.1` in this fix PR; the release commit/tag should bump it to `2.2.2` after merge

## Validation

- lint passes
- full test suite passes: 786 tests across Hessian v3/v4, protocol 1.0/2.0, and debug enabled/disabled paths
- added assertions that generated debug files are loaded as real modules through `require.cache`
- verified the patched implementation with `egg-bin bundle` in the Chair application: bundle completed with 335 output files